### PR TITLE
feat: ownership-based authorization across services, schedules, users and bookings

### DIFF
--- a/server/src/admin/admin.service.spec.ts
+++ b/server/src/admin/admin.service.spec.ts
@@ -58,7 +58,7 @@ describe('AdminService', () => {
       ],
     }).compile();
     prisma = module.get<DeepMockProxy<PrismaService>>(PrismaService);
-    service = module.get<DeepMockProxy<AdminService>>(AdminService);
+    service = module.get<AdminService>(AdminService);
   });
   afterEach(async () => {
     await module.close();
@@ -251,14 +251,22 @@ describe('AdminService', () => {
         businesses: [{ id: businessId }]
       } as any);
 
-      prisma.booking.findMany
-        .mockResolvedValueOnce([
-          { date: new Date('2023-01-01T10:00:00Z'), finalPrice: 100, status: 'COMPLETED', timezone: 'UTC' },
-          { date: new Date('2023-01-02T10:00:00Z'), finalPrice: 150, status: 'COMPLETED', timezone: 'UTC' },
-        ] as any)
-        .mockResolvedValueOnce([
-          { service: { name: 'Service 1' }, date: new Date('2023-01-01'), finalPrice: 100, status: 'COMPLETED', timezone: 'UTC' },
-        ] as any);
+      prisma.booking.findMany.mockResolvedValue([
+        {
+          date: new Date('2023-01-01T10:00:00Z'),
+          finalPrice: 100,
+          status: 'COMPLETED',
+          timezone: 'UTC',
+          service: { name: 'Service 1' }
+        },
+        {
+          date: new Date('2023-02-02T10:00:00Z'),
+          finalPrice: 150,
+          status: 'COMPLETED',
+          timezone: 'UTC',
+          service: { name: 'Service 2' }
+        },
+      ] as any);
       prisma.booking.count.mockResolvedValue(5);
       prisma.booking.aggregate.mockResolvedValue({ _sum: { finalPrice: 250 } } as any);
 
@@ -268,7 +276,15 @@ describe('AdminService', () => {
         totalRevenue: 250,
         groupFormat: 'YYYY-MM-DD',
         bookingByService: expect.arrayContaining([
-          expect.objectContaining({ serviceName: 'Service 1', }),
+          expect.objectContaining({
+            serviceName: 'Service 1',
+            date: '2023-01-01T10:00:00.000Z',
+            finalPrice: 100,
+            status: 'COMPLETED',
+            timezone: 'UTC',
+          },
+          
+        ),
         ]),
       }));
     })
@@ -277,14 +293,22 @@ describe('AdminService', () => {
         id: userId,
         businesses: [{ id: businessId }]
       } as any);
-      prisma.booking.findMany
-        .mockResolvedValueOnce([
-          { date: new Date('2023-01-01T10:00:00Z'), finalPrice: 100, status: 'COMPLETED', timezone: 'UTC' },
-          { date: new Date('2023-01-02T10:00:00Z'), finalPrice: 150, status: 'COMPLETED', timezone: 'UTC' },
-        ] as any)
-        .mockResolvedValueOnce([
-          { service: { name: 'Service 1' }, date: new Date('2023-01-01'), finalPrice: 100, status: 'COMPLETED', timezone: 'UTC' },
-        ] as any);
+      prisma.booking.findMany.mockResolvedValue([
+        {
+          date: new Date('2023-01-01T10:00:00Z'),
+          finalPrice: 100,
+          status: 'COMPLETED',
+          timezone: 'UTC',
+          service: { name: 'Service 1' }
+        },
+        {
+          date: new Date('2023-02-02T10:00:00Z'),
+          finalPrice: 150,
+          status: 'COMPLETED',
+          timezone: 'UTC',
+          service: { name: 'Service 2' }
+        },
+      ] as any);
       prisma.booking.count.mockResolvedValue(5);
       prisma.booking.aggregate.mockResolvedValue({ _sum: { finalPrice: 250 } } as any);
 
@@ -296,14 +320,22 @@ describe('AdminService', () => {
         id: userId,
         businesses: [{ id: businessId }]
       } as any);
-      prisma.booking.findMany
-        .mockResolvedValueOnce([
-          { date: new Date('2023-01-01T10:00:00Z'), finalPrice: 100, status: 'COMPLETED', timezone: 'UTC' },
-          { date: new Date('2023-01-02T10:00:00Z'), finalPrice: 150, status: 'COMPLETED', timezone: 'UTC' },
-        ] as any)
-        .mockResolvedValueOnce([
-          { service: { name: 'Service 1' }, date: new Date('2023-01-01'), finalPrice: 100, status: 'COMPLETED', timezone: 'UTC' },
-        ] as any);
+      prisma.booking.findMany.mockResolvedValue([
+        {
+          date: new Date('2023-01-01T10:00:00Z'),
+          finalPrice: 100,
+          status: 'COMPLETED',
+          timezone: 'UTC',
+          service: { name: 'Service 1' }
+        },
+        {
+          date: new Date('2023-02-02T10:00:00Z'),
+          finalPrice: 150,
+          status: 'COMPLETED',
+          timezone: 'UTC',
+          service: { name: 'Service 2' }
+        },
+      ] as any);
       prisma.booking.count.mockResolvedValue(5);
       prisma.booking.aggregate.mockResolvedValue({ _sum: { finalPrice: 250 } } as any);
 

--- a/server/src/auth/auth.service.spec.ts
+++ b/server/src/auth/auth.service.spec.ts
@@ -3,6 +3,7 @@ import { AuthService } from './auth.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JwtService } from '@nestjs/jwt';
 import { BadRequestException, ConflictException, ForbiddenException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 
 
 
@@ -12,21 +13,16 @@ jest.mock('bcrypt', () => ({
 }))
 describe('AuthService', () => {
   let service: AuthService;
-  let prisma: { user: { findUnique: jest.Mock; create: jest.Mock } }
+  let prisma: DeepMockProxy<PrismaService>;
   let module: TestingModule;
 
   beforeEach(async () => {
-     module = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         AuthService,
         {
           provide: PrismaService,
-          useValue: {
-            user: {
-              findUnique: jest.fn(),
-              create: jest.fn()
-            }
-          },
+          useValue: mockDeep<PrismaService>()
         },
         {
           provide: JwtService,
@@ -37,27 +33,38 @@ describe('AuthService', () => {
 
       ]
     }).compile();
-    prisma = module.get<any>(PrismaService)
+    prisma = module.get<DeepMockProxy<PrismaService>>(PrismaService)
     service = module.get<AuthService>(AuthService);
   });
-  
+
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
   describe('register', () => {
+    const mockUser = {
+        id: '1',
+        name: 'name',
+        email: 'test@test.com',
+        password:'passwordHashed',
+        phone: null,
+        role: 'CLIENT',
+        businessId: null,
+        createdAt: expect.any(Date),
+        authProvider: 'LOCAL'
+      }
     it('should throw ConflictException if email already exists', async () => {
-      prisma.user.findUnique.mockResolvedValue({ id: 1, email: 'test@test.com' })
+      prisma.user.findUnique.mockResolvedValue(mockUser as any)
       await expect(() => service.register({
-        name: 'JhonDoe',
-        email: 'email@test.com'
+        name: mockUser.name,
+        email: mockUser.email
       })).rejects.toThrow(ConflictException)
     })
     it('should throw BadRequestException if AuthProvider is LOCAL and password is null', async () => {
       prisma.user.findUnique.mockResolvedValue(null)
       await expect(() => service.register({
-        name: 'JhonDoe',
-        email: 'email@test.com',
+        name: mockUser.name,
+        email: mockUser.email,
         authProvider: 'LOCAL',
       })).rejects.toThrow(BadRequestException)
     })
@@ -72,36 +79,34 @@ describe('AuthService', () => {
     it('should return code 200 success register', async () => {
       prisma.user.findUnique.mockResolvedValue(null)
       prisma.user.create.mockResolvedValue({
-        id: 1,
+        id: '1',
         name: 'name',
         email: 'test@test.com',
         phone: null,
         role: 'CLIENT',
         businessId: null,
         createdAt: expect.any(Date),
-        bookings: [],
         authProvider: 'GOOGLE'
-      })
+      } as any)
       await expect(service.register({
         name: 'John',
         email: 'email@test.com',
         authProvider: 'GOOGLE'
       })).resolves.toEqual(expect.objectContaining({
-        id: 1,
+        id: '1',
         name: 'name',
         email: 'test@test.com',
         phone: null,
         role: 'CLIENT',
         businessId: null,
         createdAt: new Date,
-        bookings: [],
         authProvider: 'GOOGLE',
       }))
     })
   })
   describe('login', () => {
     it('should throw Unauthorized Exception if email is not valid', async () => {
-      prisma.user.findUnique.mockResolvedValue({ id: 1, email: 'test@test.com', password: '123456789', authProvider: 'LOCAL' })
+      prisma.user.findUnique.mockResolvedValue({ id: '1', email: 'test@test.com', password: '123456789', authProvider: 'LOCAL' } as any)
       await expect(() => service.login({
         password: '1234567789',
         email: 'email@test.com',
@@ -115,14 +120,14 @@ describe('AuthService', () => {
       })).rejects.toThrow(NotFoundException)
     })
     it('should throw UnauthorizedException if user is not local', async () => {
-      prisma.user.findUnique.mockResolvedValue({ id: 1, email: 'test@test.com', password: '123456789', authProvider: 'GOOGLE' })
+      prisma.user.findUnique.mockResolvedValue({ id: '1', email: 'test@test.com', password: '123456789', authProvider: 'GOOGLE' } as any)
       await expect(() => service.login({
         password: '123456789',
         email: 'email@test.com',
       })).rejects.toThrow(UnauthorizedException)
     })
     it('should throw UnauthorizedException if password is wrong', async () => {
-      prisma.user.findUnique.mockResolvedValue({ id: 1, email: 'test@test.com', password: '123456789' })
+      prisma.user.findUnique.mockResolvedValue({ id: '1', email: 'test@test.com', password: '123456789' } as any)
       await expect(() => service.login({
         password: '123456778',
         email: 'email@test.com',
@@ -139,8 +144,7 @@ describe('AuthService', () => {
         phone: null,
         businessId: null,
         createdAt: new Date(),
-        bookings: [],
-      })
+      } as any)
       const bcrypt = require('bcrypt')
       bcrypt.compare.mockResolvedValue(true)
       let jwt = module.get<any>(JwtService)
@@ -150,7 +154,7 @@ describe('AuthService', () => {
         email: 'email@test.com',
       })).resolves.toEqual(expect.objectContaining({
         accessToken: expect.any(String),
-        user: expect.objectContaining({email:'email@test.com'})
+        user: expect.objectContaining({ email: 'email@test.com' })
       }))
     })
   })

--- a/server/src/bookings/bookings.controller.ts
+++ b/server/src/bookings/bookings.controller.ts
@@ -157,7 +157,7 @@ const bookingData = {
     @Param('id') id: string,
     @Request() req: RequestWithUser,
   ): Promise<BookingDto> {
-    return this.bookingsService.remove(id, req.user);
+    return this.bookingsService.delete(id, req.user);
   }
 }
 

--- a/server/src/bookings/bookings.service.spec.ts
+++ b/server/src/bookings/bookings.service.spec.ts
@@ -52,7 +52,8 @@ describe('BookingsService', () => {
     service = module.get<BookingsService>(BookingsService);
     prisma = module.get<DeepMockProxy<PrismaService>>(PrismaService);
   })
-
+  afterEach(async()=> await module.close())
+  
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
@@ -66,32 +67,32 @@ describe('BookingsService', () => {
       expect(result).toEqual([mockBooking]);
     });
   })
-  describe('remove', () => {
+  describe('delete', () => {
     it('should throw NotFoundException if booking not found', async () => {
       prisma.booking.findUnique.mockResolvedValue(null);
       prisma.user.findUnique.mockResolvedValue(null);
-      await expect(() => service.remove('1', { userId: 'user1', role: 'CLIENT' })).rejects.toThrow(NotFoundException);
+      await expect(() => service.delete('1', { userId: 'user1', role: 'CLIENT' })).rejects.toThrow(NotFoundException);
     });
     it('should throw ForbiddenException if client is not owner', async () => {
       prisma.booking.findUnique.mockResolvedValue({ ...mockBooking, userId: 'otherUser' });
       prisma.user.findUnique.mockResolvedValue(userMock as any);
-      await expect(() => service.remove('1', { userId: 'user1', role: 'CLIENT' })).rejects.toThrow(ForbiddenException);
+      await expect(() => service.delete('1', { userId: 'user1', role: 'CLIENT' })).rejects.toThrow(ForbiddenException);
     });
     it('should throw ForbiddenException if employee tries to delete booking from another business', async () => {
       prisma.booking.findUnique.mockResolvedValue({ ...mockBooking, userId: '123' });
       prisma.user.findUnique.mockResolvedValue({ ...userMock, businessId: 'otherBusiness' } as any);
-      await expect(() => service.remove('1', { userId: 'user1', role: 'EMPLOYEE' })).rejects.toThrow(ForbiddenException);
+      await expect(() => service.delete('1', { userId: 'user1', role: 'EMPLOYEE' })).rejects.toThrow(ForbiddenException);
     });
     it('should throw ForbiddenException if ADMIN tries to delete booking from another business', async () => {
       prisma.booking.findUnique.mockResolvedValue({ ...mockBooking, userId: '123' });
       prisma.user.findUnique.mockResolvedValue({ ...userMock, businessId: 'otherBusiness' } as any);
-      await expect(() => service.remove('1', { userId: 'user1', role: 'ADMIN' })).rejects.toThrow(ForbiddenException);
+      await expect(() => service.delete('1', { userId: 'user1', role: 'ADMIN' })).rejects.toThrow(ForbiddenException);
     });
     it('should delete the booking if user is EMPLOYEE', async () => {
       prisma.booking.findUnique.mockResolvedValue(mockBooking);
       prisma.user.findUnique.mockResolvedValue(userMock as any);
       prisma.booking.delete.mockResolvedValue(mockBooking);
-      const result = await service.remove('1', { userId: 'user1', role: 'EMPLOYEE' });
+      const result = await service.delete('1', { userId: 'user1', role: 'EMPLOYEE' });
       expect(result).toBeDefined();
     });
 
@@ -99,7 +100,7 @@ describe('BookingsService', () => {
       prisma.booking.findUnique.mockResolvedValue(mockBooking);
       prisma.user.findUnique.mockResolvedValue(userMock as any);
       prisma.booking.delete.mockResolvedValue(mockBooking);
-      const result = await service.remove('1', { userId: 'user1', role: 'ADMIN' });
+      const result = await service.delete('1', { userId: 'user1', role: 'ADMIN' });
       expect(result).toBeDefined();
     });
   })

--- a/server/src/bookings/bookings.service.ts
+++ b/server/src/bookings/bookings.service.ts
@@ -11,6 +11,7 @@ import { UpdateBookingDto } from './dto/updateBookingDto.dto';
 import { BookingStatus } from '@prisma/client';
 import { CreateBookingDto } from './dto/createBookingDto.dto';
 import { format } from 'date-fns';
+import { toMinutes } from '../utils/toMinutes';
 
 @Injectable()
 export class BookingsService {
@@ -89,11 +90,8 @@ export class BookingsService {
     }
   
     const endTimeStr = format(localEndTime, 'HH:mm');
-
-    const toMinutes = (h: number, m: number) => h*60 + m;
-    const endMinutes =toMinutes(localEndTime.getHours(), localEndTime.getMinutes())
-    const [closeH, closeM] = schedule.to.split(':').map(Number)
-    const closeMinutes = toMinutes(closeH, closeM)
+    const endMinutes = toMinutes(endTimeStr)
+    const closeMinutes = toMinutes(schedule.to)
 
     if (endMinutes > closeMinutes) {
       throw new BadRequestException(
@@ -171,24 +169,34 @@ export class BookingsService {
       },
     });
   }
-  async remove(
+  async delete(
     id: string,
-    user: { userId: string; role: string },
+    user: { 
+      userId: string,
+      role: string },
   ): Promise<BookingDto> {
-    const booking = await this.prisma.booking.findUnique({ where: { id } });
+    if(!id || !user ) throw new BadRequestException('Bad Request')
+    const booking = await this.prisma.booking.findUnique({ where: {
+      id,
+      userId: user.userId } });
     if (!booking) {
       throw new NotFoundException('Booking not found');
     }
     const bookingUser = await this.prisma.user.findUnique({
-      where: { id: user.userId || undefined },
+      where: { id: user.userId},
     });
-    const userBusinessId = bookingUser?.businessId;
-    if (user.role === 'CLIENT' && booking.userId !== user.userId) {
-      throw new ForbiddenException('Clients can only delete their own bookings');
+    if(!bookingUser) throw new NotFoundException('Not found')
+    const userBusinessId = bookingUser.businessId;
+  if(user.role === 'CLIENT'){
+    if (booking.userId !== user.userId) {
+      throw new ForbiddenException('Forbidden');
     }
-    if (['EMPLOYEE', 'ADMIN'].includes(user.role) && userBusinessId !== booking.businessId) {
-      throw new ForbiddenException('Employees can only delete bookings of their business');
+  }
+  if(user.role === 'EMPLOYEE' || user.role === 'ADMIN'){
+    if (userBusinessId !== booking.businessId) {
+      throw new ForbiddenException('Forbidden');
     }
+  }
     const deleted = await this.prisma.booking.delete({ where: { id } });
     return {
       id: deleted.id,

--- a/server/src/business/business.service.ts
+++ b/server/src/business/business.service.ts
@@ -123,8 +123,8 @@ export class BusinessService {
       );
     }
 
-    return this.prisma.business.create({
-      data: {
+    return await this.prisma.business.create({
+      data:{
         name: data.name,
         ownerId: data.ownerId,
       },

--- a/server/src/schedules/dto/create-schedule.dto.ts
+++ b/server/src/schedules/dto/create-schedule.dto.ts
@@ -8,7 +8,7 @@ export class CreateScheduleDto {
   })
   @IsNumber()
   @IsNotEmpty()
-  dayOfWeek: number;
+  dayOfWeek!: number;
 
   @ApiProperty({
     description: 'Start time',
@@ -16,7 +16,7 @@ export class CreateScheduleDto {
   })
   @IsString()
   @IsNotEmpty()
-  from: string;
+  from!: string;
 
   @ApiProperty({
     description: 'End time',
@@ -24,7 +24,7 @@ export class CreateScheduleDto {
   })
   @IsString()
   @IsNotEmpty()
-  to: string;
+  to!: string;
 
   @ApiProperty({
     description: 'Business ID',
@@ -32,5 +32,5 @@ export class CreateScheduleDto {
   })
   @IsUUID()
   @IsNotEmpty()
-  businessId: string;
+  businessId!: string;
 }

--- a/server/src/schedules/schedules.controller.ts
+++ b/server/src/schedules/schedules.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
   BadRequestException,
   Put,
+  Request
 } from '@nestjs/common';
 import { SchedulesService } from './schedules.service';
 import {
@@ -23,6 +24,8 @@ import { Roles } from '../decorators/roles.decorator';
 import { ScheduleDto } from './dto/schedulesDto.dto';
 import { CreateScheduleDto } from './dto/create-schedule.dto';
 import { UpdateScheduleDto } from './dto/updateSchedules.dto';
+import { RequestWithUser } from '../types/express-request.interface';
+
 
 @ApiTags('Schedules')
 @Controller('schedules')
@@ -39,8 +42,11 @@ export class SchedulesController {
     description: 'Schedule deleted',
     type: ScheduleDto,
   })
-  async delete(@Param('id') id: string): Promise<Schedule> {
-    return this.schedulesService.delete(id);
+  async delete(
+    @Request() req: RequestWithUser,
+    @Param('id') id: string):
+     Promise<Schedule> {
+    return this.schedulesService.delete(id, req.user.userId);
   }
 
   @Get()
@@ -53,8 +59,23 @@ export class SchedulesController {
     description: 'List of schedules',
     type: [ScheduleDto],
   })
-  async findAll(): Promise<Schedule[]> {
-    return this.schedulesService.findAll();
+  async findAll(@Request() req:RequestWithUser): Promise<Schedule[]> {
+    const userId = req.user.userId 
+    return this.schedulesService.findAll(userId);
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ADMIN')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a schedule by ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Get Schedule by ID',
+    type: ScheduleDto,
+  })
+  async findOne(@Param('id') id: string): Promise<Schedule> {
+    return this.schedulesService.findOne(id);
   }
 
   @Post()
@@ -90,10 +111,11 @@ export class SchedulesController {
   })
   @ApiResponse({ status: 400, description: 'Error updating schedule' })
   async update(
+    @Request() req: RequestWithUser,
     @Param('id') id: string,
     @Body() updateScheduleDto: UpdateScheduleDto,
   ): Promise<Schedule> {
-    const schedule = await this.schedulesService.update(id, updateScheduleDto);
+    const schedule = await this.schedulesService.update(id, updateScheduleDto, req.user.userId);
     if (!schedule) {
       throw new BadRequestException('Schedule not found');
     }

--- a/server/src/schedules/schedules.service.spec.ts
+++ b/server/src/schedules/schedules.service.spec.ts
@@ -1,18 +1,152 @@
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 import { Test, TestingModule } from '@nestjs/testing';
 import { SchedulesService } from './schedules.service';
+import { PrismaService } from '../../prisma/prisma.service'
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { UpdateScheduleDto } from './dto/updateSchedules.dto';
 
 describe('SchedulesService', () => {
+  let prisma: DeepMockProxy<PrismaService>;
   let service: SchedulesService;
+  let module: TestingModule;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [SchedulesService],
+    module = await Test.createTestingModule({
+      providers: [SchedulesService,
+        {
+          provide: PrismaService,
+          useValue: mockDeep<PrismaService>()
+        }
+      ],
     }).compile();
-
+    prisma = module.get<DeepMockProxy<PrismaService>>(PrismaService);
     service = module.get<SchedulesService>(SchedulesService);
   });
+  afterEach(async () => {
+    await module.close()
+  })
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  })
+  describe('FindAll', () => {
+    it('should throw BadRequestException if userId is not provided', async () => {
+      await expect(service.findAll(null as any)).rejects.toThrow(BadRequestException);
+    })
+    it('should get all owner schedules', async () => {
+      prisma.business.findMany.mockResolvedValue([{ id: 'biz-id' }] as any)
+      prisma.schedule.findMany.mockResolvedValue([{ id: 'schedule-id', dayOfWeek: 1, from: '10:00', to: '12:30', businessId: 'biz-213' }] as any)
+      const result = await service.findAll('userId-123')
+      expect(result).toEqual(
+        [{
+          id: 'schedule-id',
+          dayOfWeek: 1,
+          from: '10:00',
+          to: '12:30',
+          businessId: 'biz-213'
+        }]
+      )
+    })
   });
-});
+  describe('FindOne', () => {
+    it('should get schedule by id', async () => {
+      prisma.schedule.findUnique.mockResolvedValue({ id: 'schedule-id', dayOfWeek: 1, from: '10:00', to: '12:30', businessId: 'biz-213' } as any)
+      const result = await service.findOne('schedule-id')
+      expect(result).toEqual(
+        {
+          id: 'schedule-id',
+          dayOfWeek: 1,
+          from: '10:00',
+          to: '12:30',
+          businessId: 'biz-213'
+        }
+      )
+    })
+    it('should throw BadRequestException if id is not provided', async () => {
+      await expect(service.findOne(null as any)).rejects.toThrow(BadRequestException);
+    })
+    it('should throw NotFoundException if schedule id is not found', async () => {
+      await expect(service.findOne('schedule-123')).rejects.toThrow(NotFoundException);
+    })
+  });
+  describe('Create', () => {
+    it('should throw BadRequestException if fromMinutes > or = than toMinutes', async () => {
+      await expect(service.create({ from: '10:00', to: '09:00', dayOfWeek: 1, businessId: 'biz1' })).rejects.toThrow(BadRequestException);
+    })
+    it('should create a schedule', async () => {
+      prisma.schedule.create.mockResolvedValue({ id: 'schedule1', from: '17:00', to: '19:00', dayOfWeek: 1, businessId: 'biz1' })
+      const result = await service.create({ from: '17:00', to: '19:00', dayOfWeek: 1, businessId: 'biz1' })
+      expect(result).toEqual({
+        id: 'schedule1',
+        from: '17:00',
+        to: '19:00',
+        dayOfWeek: 1,
+        businessId: 'biz1'
+      })
+    })
+  });
+  describe('Delete', () => {
+    it('should throw BadRequestException if id is not provided', async () => {
+      await expect(service.delete(null as any, 'userId')).rejects.toThrow(BadRequestException)
+    })
+    it('should throw BadRequestException if userId is not provided', async () => {
+      await expect(service.delete('schedule-id', null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should throw NotFoundException  if schedule not found', async () => {
+      await expect(service.delete('schedule-id2', 'user2')).rejects.toThrow(NotFoundException)
+    })
+    it('should throw NotFoundException  if business not found', async () => {
+      prisma.schedule.findUnique.mockResolvedValue({ id: 'schedule-id', businessId: 'biz-1' } as any);
+      await expect(service.delete('schedule-id2', 'user2')).rejects.toThrow(NotFoundException)
+    })
+    it('should throw ForbiddenException  if ownerId is not equal to businessId', async () => {
+      prisma.schedule.findUnique.mockResolvedValue({ id: 'schedule-id2' } as any)
+      prisma.business.findUnique.mockResolvedValue({ ownerId: 'user1' } as any)
+      await expect(service.delete('schedule-id2', 'user2')).rejects.toThrow(ForbiddenException)
+    })
+    it('should delete schedule', async () => {
+      prisma.schedule.findUnique.mockResolvedValue({ id: 'schedule-id' } as any)
+      prisma.business.findUnique.mockResolvedValue({ id: 'biz-1', ownerId: 'user2' } as any)
+      await service.delete('schedule-id', 'user2');
+      expect(prisma.schedule.delete).toHaveBeenCalledWith({
+        where: { id: 'schedule-id' }
+      });
+    })
+  });
+  describe('Update', () => {
+    it('should throw BadRequestException if arg not provided', async () => {
+      await expect(service.update(null as any, { from: '10:00', to: '12:00' } as any, 'userId')).rejects.toThrow(BadRequestException)
+    })
+    it('should throw BadRequestException if arg not provided', async () => {
+      await expect(service.update('schedule1', { from: '10:00', to: '12:00' } as any, null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should throw NotFoundException  if schedule not found', async () => {
+      prisma.schedule.findUnique.mockResolvedValue( null as any);
+      await expect(service.update('schedule-id', { from: '10:00', to: '12:00' } as any, 'user2')).rejects.toThrow(NotFoundException)
+    })
+    it('should throw BadRequestException if fromMinutes > or = than toMinutes', async () => {
+      prisma.schedule.findUnique.mockResolvedValue({ id: 'schedule-id' } as any)
+      prisma.business.findUnique.mockResolvedValue({ id: 'biz-1', ownerId: 'userId' } as any)
+      await expect(service.update('schedule-id1',{ from: '10:00', to: '09:00', dayOfWeek: 1, }, 'userId')).rejects.toThrow(BadRequestException);
+    })
+    it('should throw NotFoundException  if business not found', async () => {
+      prisma.schedule.findUnique.mockResolvedValue({ id: 'schedule-id2' } as any);
+      prisma.business.findUnique.mockResolvedValue(null as any);
+      await expect(service.update('schedule-id2', { from: '10:00', to: '12:00' } as any, 'user2')).rejects.toThrow(NotFoundException)
+    })
+    it('should throw ForbiddenException  if ownerId is not equal to businessId', async () => {
+      prisma.schedule.findUnique.mockResolvedValue({ id: 'schedule-id2' } as any)
+      prisma.business.findUnique.mockResolvedValue({ ownerId: 'user1' } as any)
+      await expect(service.update('schedule-id2', { from: '10:00', to: '12:00' } as any, 'user2')).rejects.toThrow(ForbiddenException)
+    })
+    it('should update schedule', async () => {
+      prisma.schedule.findUnique.mockResolvedValue({ id: 'schedule-id' } as any)
+      prisma.business.findUnique.mockResolvedValue({ id: 'biz-1', ownerId: 'user2' } as any)
+      await service.update('schedule-id', {  from: '10:00', to: '12:00' } as any, 'user2');
+      expect(prisma.schedule.update).toHaveBeenCalledWith({
+        where: { id: 'schedule-id' },
+        data: { from: '10:00', to: '12:00' }
+      });
+    })
+  });
+})

--- a/server/src/schedules/schedules.service.ts
+++ b/server/src/schedules/schedules.service.ts
@@ -1,26 +1,63 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'prisma/prisma.service';
 import { Schedule } from '@prisma/client';
 import { CreateScheduleDto } from './dto/create-schedule.dto';
 import { UpdateScheduleDto } from './dto/updateSchedules.dto';
+import { toMinutes } from '../utils/toMinutes';
 @Injectable()
 export class SchedulesService {
-  constructor(private prisma: PrismaService) {}
+  constructor(private prisma: PrismaService) { }
 
-  async findAll(): Promise<Schedule[]> {
-    const schedules = await this.prisma.schedule.findMany();
+  async findAll(userId: string): Promise<Schedule[]> {
+    if (!userId) throw new BadRequestException('userId is not provided')
+    const business = await this.prisma.business.findMany({
+      where: {
+        ownerId: userId
+      }
+    })
+    const businessIds = business.map((e) => e.id)
+    const schedules = await this.prisma.schedule.findMany(
+      {
+        where: {
+          businessId: { in: businessIds }
+        }
+      }
+
+    )
     return schedules;
   }
-
+  async findOne(id: string): Promise<Schedule> {
+    if (!id) throw new BadRequestException('ID IS NOT PROVIDED')
+    const schedule = await this.prisma.schedule.findUnique({ where: { id } })
+    if (!schedule) throw new NotFoundException('Schedule not found')
+    return schedule;
+  }
   async create(data: CreateScheduleDto): Promise<Schedule> {
-    if(data.from >= data.to) {
+    const minutesFrom = toMinutes(data.from)
+    const minutesTo = toMinutes(data.to)
+    if (minutesFrom >= minutesTo) {
+
       throw new BadRequestException('start time must be before end time');
     }
     return this.prisma.schedule.create({
       data,
     });
   }
-  async delete(id: string): Promise<Schedule> {
+  async delete(
+    id: string,
+    userId: string
+  ): Promise<Schedule> {
+    if (!id || !userId) throw new BadRequestException('args not provided')
+
+    const schedule = await this.prisma.schedule.findUnique({
+      where: { id: id }
+    });
+    if (!schedule) throw new NotFoundException('Schedule not found')
+    const business = await this.prisma.business.findUnique({
+      where: { id: schedule.businessId }
+    })
+    if (!business) throw new NotFoundException('Business not found')
+    if (business.ownerId != userId) throw new ForbiddenException('You do not have acces to delete this schedule')
     return this.prisma.schedule.delete({
       where: { id },
     });
@@ -28,11 +65,23 @@ export class SchedulesService {
   async update(
     id: string,
     updateScheduleDto: UpdateScheduleDto,
+    userId: string
   ): Promise<Schedule> {
-   if (updateScheduleDto.from && updateScheduleDto.to && updateScheduleDto.from >= updateScheduleDto.to) {
-  throw new BadRequestException('start time must be before end time');
-}
-return this.prisma.schedule.update({
+    if (!id || !userId) throw new BadRequestException('ARG not provided')
+    const currentSchedule = await this.prisma.schedule.findUnique({ where: { id: id } })
+    if (!currentSchedule) throw new NotFoundException('ID schedule is not in DATABASE')
+    const business = await this.prisma.business.findUnique({ where: { id: currentSchedule?.businessId } })
+    if (!business) throw new NotFoundException('ID business is not in DATABASE')
+    if(business.ownerId != userId) throw new ForbiddenException('Not Authorized to update this schedule')
+    const from = updateScheduleDto.from ?? currentSchedule!.from
+    const to = updateScheduleDto.to ?? currentSchedule!.to
+    const minutesFrom = toMinutes(from)
+    const minutesTo = toMinutes(to)
+
+    if (minutesFrom >= minutesTo) {
+      throw new BadRequestException('start time must be before end time');
+    }
+    return this.prisma.schedule.update({
       where: { id },
       data: updateScheduleDto,
     });

--- a/server/src/services/dto/businessWithService.dto.ts
+++ b/server/src/services/dto/businessWithService.dto.ts
@@ -1,0 +1,6 @@
+import { Service } from '@prisma/client';
+
+export interface BusinessWithServices {
+    name: string;
+    services: Service[];
+}

--- a/server/src/services/dto/create-service.dto.ts
+++ b/server/src/services/dto/create-service.dto.ts
@@ -15,7 +15,7 @@ export class CreateServiceDto {
   })
   @IsString()
   @IsNotEmpty()
-  name: string;
+  name!: string;
 
   @ApiPropertyOptional({
     description: 'Service description',
@@ -31,15 +31,14 @@ export class CreateServiceDto {
   })
   @IsNumber()
   @Min(1, { message: 'Duration must be at least 1 minute' })
-  durationMin: number;
+  durationMin!: number;
 
   @ApiProperty({
     description: 'Price in ARS',
     example: 2500,
   })
   @IsNumber()
-  @IsOptional()
-  price: number;
+  price!: number;
 
   @ApiProperty({
     description: 'Business ID',
@@ -47,5 +46,5 @@ export class CreateServiceDto {
   })
   @IsUUID()
   @IsNotEmpty()
-  businessId: string;
+  businessId!: string;
 }

--- a/server/src/services/dto/service.dto.ts
+++ b/server/src/services/dto/service.dto.ts
@@ -7,5 +7,5 @@ export class ServiceDto extends CreateServiceDto {
     example: '572ba60c-1fc5-4bc3-8472-afee5062b0e1',
   })
   @IsUUID()
-  id: string;
+  id!: string;
 }

--- a/server/src/services/dto/updateServices.dto.ts
+++ b/server/src/services/dto/updateServices.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType, OmitType } from '@nestjs/mapped-types';
 import { CreateServiceDto } from './create-service.dto';
 
-export class UpdateServiceDto extends PartialType(CreateServiceDto) {}
+export class UpdateServiceDto extends PartialType(OmitType(CreateServiceDto, ['businessId'])) {}

--- a/server/src/services/services.controller.ts
+++ b/server/src/services/services.controller.ts
@@ -5,7 +5,6 @@ import {
   Body,
   Delete,
   Param,
-  BadRequestException,
   UseGuards,
   Put,
   Request,
@@ -25,20 +24,21 @@ import { ServiceDto } from './dto/service.dto';
 import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/updateServices.dto';
 import { RequestWithUser } from '../types/express-request.interface';
+import { BusinessWithServices } from './dto/businessWithService.dto';
 
 @ApiTags('Services')
 @Controller('services')
 export class ServicesController {
-  constructor(private readonly servicesService: ServicesService) {}
+  constructor(private readonly servicesService: ServicesService) { }
 
   @Get()
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN', 'CLIENT')
+  @Roles('ADMIN')
   @ApiOperation({ summary: 'Get all services' })
   @ApiResponse({ status: 200, type: [ServiceDto] })
-  async findAll(): Promise<Service[]> {
-    return this.servicesService.findAll();
+  async findAll(@Request() req: RequestWithUser): Promise<BusinessWithServices[]> {
+    return this.servicesService.findAll(req.user.userId);
   }
 
   @Get('my-business')
@@ -51,7 +51,7 @@ export class ServicesController {
     return this.servicesService.getServicesByEmployee(req.user.userId);
   }
 
-  @Delete(':id')
+  @Delete(':businessId/:id')
   @ApiBearerAuth()
   @Roles('ADMIN')
   @UseGuards(JwtAuthGuard, RolesGuard)
@@ -61,19 +61,26 @@ export class ServicesController {
     description: 'Servicio eliminado',
     type: ServiceDto,
   })
-  async delete(@Param('id') id: string): Promise<Service> {
-    return this.servicesService.delete(id);
+  async delete(
+    @Param('id') id: string,
+    @Request() req: RequestWithUser,
+    @Param('businessId') businessId: string)
+    : Promise<Service> {
+    return this.servicesService.delete(id, req.user.userId, businessId);
   }
 
 
   @Get(':businessId')
   @ApiBearerAuth()
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ADMIN', 'CLIENT')
+  @Roles('ADMIN')
   @ApiOperation({ summary: 'Get all services' })
   @ApiResponse({ status: 200, type: [ServiceDto] })
-  async findById(@Param('businessId') businessId: string): Promise<Service[]> {
-    return this.servicesService.findBy(businessId);
+  async findById(
+    @Param('businessId') businessId: string,
+    @Request() req: RequestWithUser)
+    : Promise<Service[]> {
+    return this.servicesService.getServicesByBusinessId(businessId, req.user.userId,);
   }
 
   @Post()
@@ -82,17 +89,13 @@ export class ServicesController {
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Create new service' })
   @ApiResponse({ status: 201, type: ServiceDto })
-  async create(@Body() body: CreateServiceDto): Promise<Service> {
-    try {
-      return this.servicesService.create(body);
-    } catch (error) {
-      if (error instanceof Error) {
-        throw new BadRequestException(error.message);
-      }
-      throw new BadRequestException('Unknown error occurred');
-    }
+  async create(
+    @Request() req: RequestWithUser,
+    @Body() body: CreateServiceDto)
+    : Promise<Service> {
+      return this.servicesService.create(body,req.user.userId);
   }
-  @Put(':id')
+  @Put(':businessId/:id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ADMIN')
   @ApiBearerAuth()
@@ -100,12 +103,10 @@ export class ServicesController {
   @ApiResponse({ status: 200, type: ServiceDto })
   async update(
     @Param('id') id: string,
+    @Param('businessId') businessId: string,
+    @Request() req: RequestWithUser,
     @Body() updateServiceDto: UpdateServiceDto,
   ): Promise<Service> {
-    const service = await this.servicesService.update(id, updateServiceDto);
-    if (!service) {
-      throw new BadRequestException('Service not found');
-    }
-    return service;
+    return await this.servicesService.update(id, updateServiceDto, req.user.userId, businessId);
   }
 }

--- a/server/src/services/services.service.spec.ts
+++ b/server/src/services/services.service.spec.ts
@@ -1,18 +1,232 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { ServicesService } from './services.service';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+  ConflictException,
+  ForbiddenException,
+  UnprocessableEntityException
+} from '@nestjs/common';
+
+
 
 describe('ServicesService', () => {
   let service: ServicesService;
-
+  let prisma: DeepMockProxy<PrismaService>;
+  let module: TestingModule
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [ServicesService],
+    module = await Test.createTestingModule({
+      providers: [
+        ServicesService,
+        {
+          provide: PrismaService,
+          useValue: mockDeep<PrismaService>()
+        }
+      ],
     }).compile();
 
     service = module.get<ServicesService>(ServicesService);
+    prisma = module.get<DeepMockProxy<PrismaService>>(PrismaService)
   });
+  afterEach(async () => await module.close())
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+  describe('getServicesByBusinessId', () => {
+    it('should throw BadRequestException if req not provided', async () => {
+      await expect(service.getServicesByBusinessId(null as any, null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should throw ForbiddenException if business is null', async () => {
+      prisma.business.findFirst.mockResolvedValue(null)
+      await expect(service.getServicesByBusinessId('biz-1', 'user2')).rejects.toThrow(ForbiddenException)
+    })
+    it('should return services by businessId', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz1',
+          ownerId: 'user1',
+          services: [
+            { id: 'svc-1', name: 'Corte', price: 5000, durationMin: 30, businessId: 'biz1' },
+          ],
+        } as any)
+      const result = await service.getServicesByBusinessId('biz1', 'user1')
+      expect(result).toEqual([
+        { id: 'svc-1', name: 'Corte', price: 5000, durationMin: 30, businessId: 'biz1' },
+      ])
+
+    })
+  })
+  describe('findAll', () => {
+    it('should throw BadRequestException if req not provided', async () => {
+      await expect(service.findAll(null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should return all services by userId', async () => {
+      prisma.business.findMany.mockResolvedValue(
+        [{
+          name: 'biz',
+          services: [
+            { id: 'svc-1', name: 'Corte', price: 5000, durationMin: 30, businessId: 'biz1' },
+          ],
+        }] as any)
+      const result = await service.findAll('user1')
+      expect(result).toEqual([{
+        name: 'biz',
+        services: [{ id: 'svc-1', name: 'Corte', price: 5000, durationMin: 30, businessId: 'biz1' }],
+      }])
+
+    })
+  })
+  describe('create', () => {
+    it('should throw ForbiddenException if business is null', async () => {
+      prisma.business.findFirst.mockResolvedValue(null)
+      await expect(service.create({ name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-1' }, 'user2')).rejects.toThrow(ForbiddenException)
+    })
+    it('should return new service', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.create.mockResolvedValue({ name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-1' } as any)
+      const result = await service.create({ name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-1' }, 'user2')
+      expect(result).toEqual({ name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-1' })
+    })
+    it('should throw ConflictException', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.create.mockRejectedValue(
+        new PrismaClientKnownRequestError('message', { code: 'P2002', clientVersion: '5.0.0' })
+      );
+      await expect(service.create(
+        {
+          name: 'biz',
+          durationMin: 10,
+          price: 1500,
+          businessId: 'biz-1'
+        },
+        'user2')).rejects.toThrow(ConflictException)
+    })
+    it('should throw InternalServerError', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.create.mockRejectedValue(new Error('Database crashed'))
+      await expect(service.create(
+        {
+          name: 'biz',
+          durationMin: 10,
+          price: 1500,
+          businessId: 'biz-1'
+        },
+        'user2')).rejects.toThrow(InternalServerErrorException)
+    })
+  })
+  describe('delete', () => {
+    it('should throw BadRequestException if req not provided', async () => {
+      await expect(service.delete(null as any, null as any, null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should throw ForbiddenException if business is null', async () => {
+      prisma.business.findFirst.mockResolvedValue(null)
+      await expect(service.delete('srv-id', 'user2', 'biz-1')).rejects.toThrow(ForbiddenException)
+    })
+    it('should delete a service', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz-1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.delete.mockResolvedValue({ id: 'srv-id', name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-1' } as any);
+      const result = await service.delete('srv-id', 'user2', 'biz-1')
+      expect(result).toEqual({ id: 'srv-id', name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-1' })
+    })
+    it('should throw NotFoundException', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.delete.mockRejectedValue(
+        new PrismaClientKnownRequestError('message', { code: 'P2025', clientVersion: '5.0.0' })
+      );
+      await expect(service.delete('srv-id', 'user2', 'biz-1')).rejects.toThrow(NotFoundException)
+    })
+    it('should throw InternalServerError', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.delete.mockRejectedValue(new Error('Database crashed'))
+      await expect(service.delete('srv-id', 'user2', 'biz-1')).rejects.toThrow(InternalServerErrorException)
+    })
+  })
+  describe('update', () => {
+    it('should throw BadRequestException if req not provided', async () => {
+      await expect(service.update(null as any, null as any, null as any,null as any )).rejects.toThrow(BadRequestException)
+    })
+    it('should throw ForbiddenException if business is null', async () => {
+      prisma.business.findFirst.mockResolvedValue(null)
+      await expect(service.update('srv-id', { name: 'biz-New' }, 'user2', 'biz-1')).rejects.toThrow(ForbiddenException)
+    })
+    it('should update a service', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz-1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.update.mockResolvedValue({ id: 'srv-id', name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-1' } as any);
+      const result = await service.update('srv-id', { name: 'biz-New' }, 'user2', 'biz-1')
+      expect(result).toEqual({ id: 'srv-id', name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-1' })
+    })
+    it('should throw NotFoundException', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.update.mockRejectedValue(
+        new PrismaClientKnownRequestError('message', { code: 'P2025', clientVersion: '5.0.0' })
+      );
+      await expect(service.update('srv-id', { name: 'biz-New' }, 'user2', 'biz-1')).rejects.toThrow(NotFoundException)
+    })
+    it('should throw InternalServerError', async () => {
+      prisma.business.findFirst.mockResolvedValue(
+        {
+          id: 'biz1',
+          ownerId: 'user1',
+        } as any)
+      prisma.service.update.mockRejectedValue(new Error('Database crashed'))
+      await expect(service.update('srv-id', { name: 'biz-New' }, 'user2', 'biz-1')).rejects.toThrow(InternalServerErrorException)
+    })
+  })
+  describe('getServicesByEmployee', () => {
+    it('should throw BadRequestException if req not provided', async () => {
+      await expect(service.getServicesByEmployee(null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should throw NotFoundException if business is null', async () => {
+      prisma.user.findUnique.mockResolvedValue(null)
+      await expect(service.getServicesByEmployee('employee-id')).rejects.toThrow(NotFoundException)
+    })
+    it('should throw UnprocessableEntityException if business is null', async () => {
+      prisma.user.findUnique.mockResolvedValue({businessId:null} as any)
+      await expect(service.getServicesByEmployee('employee-id')).rejects.toThrow(UnprocessableEntityException)
+    })
+    it('should return services by businessId', async () => {
+      prisma.user.findUnique.mockResolvedValue({businessId:'biz-id'} as any)
+      prisma.service.findMany.mockResolvedValue([{ id: 'srv-id', name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-id' }] as any)
+      const result = await service.getServicesByEmployee('employee-id')
+      expect(result).toEqual([{ id: 'srv-id', name: 'biz', durationMin: 10, price: 1500, businessId: 'biz-id' }])
+    })
+  })
+
 });

--- a/server/src/services/services.service.ts
+++ b/server/src/services/services.service.ts
@@ -1,65 +1,145 @@
-import { Injectable, BadRequestException, InternalServerErrorException } from '@nestjs/common';
-import { PrismaService } from '../../prisma/prisma.service';
+import {
+  Injectable,
+  BadRequestException,
+  InternalServerErrorException,
+  NotFoundException,
+  ConflictException,
+  ForbiddenException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { PrismaService, } from '../../prisma/prisma.service';
 import { Service } from '@prisma/client';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/updateServices.dto';
+import { BusinessWithServices } from './dto/businessWithService.dto';
 
 @Injectable()
+
+
 export class ServicesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) { }
 
-  async findBy(businessId: string): Promise<Service[]> {
-    return this.prisma.service.findMany({
-      where: { businessId },
+  async getServicesByBusinessId(businessId: string, userId: string): Promise<Service[]> {
+    if (!businessId || !userId) throw new BadRequestException('Args not provided')
+    const business = await this.prisma.business.findFirst({
+      where: {
+        id: businessId,
+        ownerId: userId
+      },
+      include: { services: true }
     });
+    if (!business) throw new ForbiddenException('Forbidden')
+    const service = business.services
+    return service
   }
 
-  async findAll(): Promise<Service[]> {
-    return this.prisma.service.findMany();
+  async findAll(userId: string): Promise<BusinessWithServices[]> {
+    if (!userId) throw new BadRequestException('Args not provided')
+    const businessWithServices = await this.prisma.business.findMany({
+      where: {
+        ownerId: userId
+      },
+      select: {
+        name: true,
+        services: true,
+      }
+    });
+    return businessWithServices
   }
 
-  async create(data: CreateServiceDto): Promise<Service> {
-    if (data.durationMin <= 0)
-      throw new BadRequestException('DurationMin must be at least 1 minute');
-    return this.prisma.service.create({
-      data,
-    });
+  async create(data: CreateServiceDto, userId: string): Promise<Service> {
+    const business = await this.prisma.business.findFirst({
+      where: {
+        id: data.businessId,
+        ownerId: userId
+      }
+    })
+    if (!business) throw new ForbiddenException('Forbidden')
+    try {
+      return await this.prisma.service.create({ data });
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        if (error.code === 'P2002') {
+          throw new ConflictException('A service with that name already exists');
+        }
+      }
+      throw new InternalServerErrorException('Internal Server Error')
+    }
   }
-  async delete(id: string): Promise<Service> {
-    return this.prisma.service.delete({
-      where: { id },
+  async delete(id: string, userId: string, businessId: string): Promise<Service> {
+    if (!id || !userId) throw new BadRequestException('Bad Request')
+    const business = await this.prisma.business.findFirst({
+      where: {
+        id: businessId,
+        ownerId: userId
+      }
     });
+    if (!business) throw new ForbiddenException('Forbidden')
+    try {
+      const service = await this.prisma.service.delete({
+        where: {
+          id,
+          businessId
+        },
+      });
+      return service
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        if (error.code === 'P2025') {
+          throw new NotFoundException('Not Found');
+        }
+      }
+      throw new InternalServerErrorException('Internal Server Error')
+    }
   }
   async update(
     id: string,
     updateServiceDto: UpdateServiceDto,
+    userId: string,
+    businessId: string
   ): Promise<Service> {
+    if (!id || !userId) throw new BadRequestException('Bad Request')
+    const business = await this.prisma.business.findFirst({
+      where: {
+        id: businessId,
+        ownerId: userId
+      }
+    });
+    if (!business) throw new ForbiddenException('Forbidden')
     try {
       return await this.prisma.service.update({
-        where: { id },
+        where: {
+          id,
+          businessId
+        },
         data: updateServiceDto,
       });
     } catch (error) {
-      if (error instanceof Error) {
-        throw new InternalServerErrorException(`Error updating service: ${error.message}`);
+      if (error instanceof PrismaClientKnownRequestError) {
+        if (error.code === 'P2025') throw new NotFoundException('Not Found');
       }
-      throw new InternalServerErrorException('Error updating service: Unknown error');
+      throw new InternalServerErrorException('Internal Server Error');
     }
   }
-
   async getServicesByEmployee(employeeId: string): Promise<Service[]> {
-    // First get the employee's business
+    if (!employeeId) throw new BadRequestException('Bad Request')
     const user = await this.prisma.user.findUnique({
       where: { id: employeeId },
-      select: { businessId: true },
+      select: {
+        businessId: true,
+      },
     });
 
-    if (!user || !user.businessId) {
-      throw new BadRequestException('Employee is not assigned to any business');
+    if (!user) {
+      throw new NotFoundException('Not Found');
     }
 
-    // Get all services for that business
-    return this.prisma.service.findMany({
+    if (!user.businessId) {
+      throw new UnprocessableEntityException('Employee is not assigned to any business');
+    }
+
+    return await this.prisma.service.findMany({
       where: { businessId: user.businessId },
       orderBy: { name: 'asc' },
     });

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -8,7 +8,7 @@ import {
   UseGuards,
   Put,
   Query,
-  BadRequestException,
+  Request,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/CreateUserDto.dto';
@@ -19,12 +19,13 @@ import { RolesGuard } from '../guard/roles.guard';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UpdateUserDto } from './dto/updateUser.dto';
+import { RequestWithUser } from 'src/types/express-request.interface';
 
 
 @ApiTags('Users')
 @Controller('users')
 export class UsersController {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(private readonly usersService: UsersService) { }
   @Delete(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth()
@@ -35,8 +36,10 @@ export class UsersController {
     description: 'User successfully deleted',
     type: UserDto,
   })
-  async deleteUser(@Param('id') id: string): Promise<UserDto> {
-    return this.usersService.deleteUser(id);
+  async deleteUser(
+    @Param('id') id: string,
+    @Request() req: RequestWithUser): Promise<UserDto> {
+    return await this.usersService.delete(id, req.user.userId);
   }
   @Get()
   @UseGuards(JwtAuthGuard, RolesGuard)
@@ -44,8 +47,8 @@ export class UsersController {
   @Roles('ADMIN')
   @ApiOperation({ summary: 'Get all users' })
   @ApiResponse({ status: 200, description: 'List of users', type: [UserDto] })
-  async findAll(): Promise<UserDto[]> {
-    return this.usersService.findAll();
+  async findAll(@Request() req: RequestWithUser): Promise<UserDto[]> {
+    return await this.usersService.findAll(req.user.userId);
   }
 
   @Get('search')
@@ -54,11 +57,10 @@ export class UsersController {
   @Roles('EMPLOYEE', 'ADMIN')
   @ApiOperation({ summary: 'Search users by email (EMPLOYEE/ADMIN)' })
   @ApiResponse({ status: 200, description: 'List of users matching search', type: [UserDto] })
-  async searchUsers(@Query('email') email: string): Promise<Omit<UserDto, 'password'>[]> {
-    if (!email || email.trim().length === 0) {
-      throw new BadRequestException('Email query parameter is required');
-    }
-    return this.usersService.searchByEmail(email);
+  async searchUsers(
+    @Query('email') email: string,
+    @Request() req: RequestWithUser): Promise<Omit<UserDto, 'password'>[]> {
+    return await this.usersService.searchByEmail(email, req.user.userId);
   }
 
   @Post()
@@ -71,11 +73,11 @@ export class UsersController {
     description: 'User successfully created',
     type: UserDto,
   })
-  async createUser(@Body() body: CreateUserDto): Promise<UserDto>{
-    return this.usersService.createUser(body)
+  async createUser(@Body() body: CreateUserDto): Promise<UserDto> {
+    return await this.usersService.create(body)
   }
 
-  
+
   @Put(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth()
@@ -89,11 +91,8 @@ export class UsersController {
   async updateUser(
     @Param('id') id: string,
     @Body() updateUserDto: UpdateUserDto,
+    @Request() req: RequestWithUser
   ): Promise<UserDto> {
-    const user = await this.usersService.updateUser(id, updateUserDto);
-    if (!user) {
-      throw new BadRequestException('User not found');
-    }
-    return user;
+    return await this.usersService.update(id, updateUserDto, req.user.userId);
   }
 }

--- a/server/src/users/users.service.spec.ts
+++ b/server/src/users/users.service.spec.ts
@@ -1,18 +1,129 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ConflictException, BadRequestException, NotFoundException } from '@nestjs/common';
 
 describe('UsersService', () => {
   let service: UsersService;
+  let prisma: DeepMockProxy<PrismaService>
+  let module: TestingModule
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+    module = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: PrismaService,
+          useValue: mockDeep<PrismaService>()
+        }
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
+    prisma = module.get<DeepMockProxy<PrismaService>>(PrismaService)
   });
+  afterEach(async () => await module.close())
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+  describe('findAll', () => {
+    it('should return users from admin businesses', async () => {
+      prisma.business.findMany.mockResolvedValue([{ id: 'biz-id' }] as any)
+      prisma.user.findMany.mockResolvedValue([{ name: 'user1', email: 'user@email.com' }] as any)
+      const result = await service.findAll('user12')
+      expect(result).toEqual([{
+        name: 'user1',
+        email: 'user@email.com'
+      }])
+    })
+  })
+
+  describe('create', () => {
+    it('should throw ConflictException if email already exists', async () => {
+      prisma.user.findUnique.mockResolvedValue({ email: 'user@email.com' } as any)
+      await expect(service.create({ email: 'user@email.com' } as any)).rejects.toThrow(ConflictException)
+    })
+    it('should throw BadRequestException if LOCAL auth without password', async () => {
+      prisma.user.findUnique.mockResolvedValue(null as any)
+      await expect(service.create(
+        {
+          email: 'user@email.com',
+          password: null,
+          authProvider: 'LOCAL'
+        } as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should create and return user', async () => {
+      prisma.user.findUnique.mockResolvedValue(null as any)
+      prisma.user.create.mockResolvedValue({ name: 'user1', email: 'user1@email.com', password: 'password-hashed', authProvider: 'LOCAL' } as any)
+      const result = await service.create({ name: 'user1', email: 'user1@email.com', password: 'password-hashed', authProvider: 'LOCAL' })
+      expect(result).toEqual({ name: 'user1', email: 'user1@email.com', password: 'password-hashed', authProvider: 'LOCAL' })
+    })
+  })
+
+  describe('delete', () => {
+    it('should throw BadRequestException if id not provided', async () => {
+      await expect(service.delete(null as any, null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should throw NotFoundException if user not found', async () => {
+      prisma.user.findFirst.mockResolvedValue(null as any);
+      await expect(service.delete('user1', 'admin-1')).rejects.toThrow(NotFoundException)
+    })
+    it('should delete and return user', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'user1', name: 'user' } as any);
+      prisma.user.delete.mockResolvedValue({ id: 'user1', name: 'user' } as any);
+      const result = await service.delete('user1', 'admin-1');
+      expect(result).toEqual({ id: 'user1', name: 'user' });
+    })
+  })
+
+  describe('update', () => {
+    it('should throw BadRequestException if id not provided', async () => {
+      await expect(service.update(null as any, null as any, null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should throw NotFoundException if user not found', async () => {
+      prisma.user.findFirst.mockResolvedValue(null as any);
+      await expect(service.update('user1', { name: 'user-1' }, 'userId')).rejects.toThrow(NotFoundException)
+    })
+    it('should update and return user', async () => {
+      prisma.user.findFirst.mockResolvedValue({ id: 'user1', name: 'user' } as any);
+      prisma.user.update.mockResolvedValue({ id: 'user1', name: 'user' } as any);
+      const result = await service.update('user1', { name: 'user-1' }, 'admin-1');
+      expect(result).toEqual({ id: 'user1', name: 'user' });
+    })
+  })
+
+  describe('searchByEmail', () => {
+    it('should throw BadRequestException if email not provided', async () => {
+      await expect(service.searchByEmail(null as any, null as any)).rejects.toThrow(BadRequestException)
+    })
+    it('should return users matching email', async () => {
+      prisma.business.findMany.mockResolvedValue([{ id: 'biz-id' }] as any);
+      prisma.user.findMany.mockResolvedValue([{
+            name: 'user1',
+            id: 'userId',
+            email: 'user@email.com',
+            phone: null,
+            role: 'EMPLOYEE',
+            authProvider: 'LOCAL',
+            businessId: 'biz-id',
+          }] as any);
+      const user = await service.searchByEmail('user@email.com', 'userId')
+      expect(user).toEqual(
+        [
+          {
+            name: 'user1',
+            id: 'userId',
+            email: 'user@email.com',
+            phone: null,
+            role: 'EMPLOYEE',
+            authProvider: 'LOCAL',
+            businessId: 'biz-id',
+          }
+        ]
+      )
+
+    })
+  })
 });

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable, BadRequestException} from '@nestjs/common';
+import { ConflictException, Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { User } from '@prisma/client';
 import { UpdateUserDto } from './dto/updateUser.dto';
@@ -6,65 +6,99 @@ import { CreateUserDto } from './dto/CreateUserDto.dto';
 import * as bcrypt from 'bcrypt'
 @Injectable()
 export class UsersService {
-  constructor(private prisma: PrismaService) {}
-  async findAll(): Promise<Omit<User, 'password'>[]> {
-  return this.prisma.user.findMany({
-    select: {
-      id: true,
-      name: true,
-      email: true,
-      phone: true,
-      role: true,
-      authProvider: true,
-      businessId: true,
-      createdAt: true,
-      bookings: true,
-      updatedAt: true
-    },
-  });
+  constructor(private prisma: PrismaService) { }
+  async findAll(userId: string): Promise<Omit<User, 'password'>[]> {
+    const businesses = await this.prisma.business.findMany({
+      where: { ownerId: userId },
+      select: { id: true }
+    });
+    const businessIds = businesses.map(b => b.id);
+    return await this.prisma.user.findMany({
+      where: { businessId: { in: businessIds } },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        phone: true,
+        role: true,
+        authProvider: true,
+        businessId: true,
+        createdAt: true,
+        updatedAt: true,
+      }
+    });
   }
 
-  async createUser(body: CreateUserDto): Promise<User> {
+  async create(body: CreateUserDto): Promise<User> {
     const existing = await this.prisma.user.findUnique({
-      where:{email:body.email}
+      where: { email: body.email }
     })
-    if(existing) throw new ConflictException('Email already in use')
+    if (existing) throw new ConflictException('Email already in use')
     if (body.authProvider === 'LOCAL' && !body.password) {
-    throw new BadRequestException('Password is required for local authentication');
-  }
+      throw new BadRequestException('Password is required for local authentication');
+    }
     const hashedPassword = body.password
-    ? await bcrypt.hash(body.password, 10)
-    : undefined
-    return this.prisma.user.create({
-      data:{
+      ? await bcrypt.hash(body.password, 10)
+      : undefined
+    return await this.prisma.user.create({
+      data: {
         ...body,
         password: hashedPassword,
-        phone: body.phone?? undefined
+        phone: body.phone ?? undefined
       }
     }
     );
   }
-  async deleteUser(id: string): Promise<User> {
-    return this.prisma.user.delete({
+  async delete(id: string, userId: string): Promise<User> {
+    if (!id) throw new BadRequestException('args not provided')
+    const userToDelete = await this.prisma.user.findFirst(
+      {
+        where: {
+          id: id,
+          business: {
+            ownerId: userId
+          }
+        },
+      })
+    if (!userToDelete) throw new NotFoundException('user not found')
+    return await this.prisma.user.delete({
       where: { id },
     });
   }
-  async updateUser(id: string, updateUserDto: UpdateUserDto): Promise<User> {
-    return this.prisma.user.update({
+  async update(id: string, updateUserDto: UpdateUserDto, userId: string): Promise<User> {
+    if (!id) throw new BadRequestException('args not provided')
+    const userToUpdate = await this.prisma.user.findFirst(
+      {
+        where: {
+          id: id,
+          business: {
+            ownerId: userId
+          }
+        },
+      })
+    if (!userToUpdate) throw new NotFoundException('user not found')
+    return await this.prisma.user.update({
       where: { id },
       data: updateUserDto,
     });
   }
 
-  async searchByEmail(email: string): Promise<Omit<User, 'password'>[]> {
-    return this.prisma.user.findMany({
+  async searchByEmail(email: string, userId: string): Promise<Omit<User, 'password'>[]> {
+    if (!email) throw new BadRequestException('args not provided')
+    const businesses = await this.prisma.business.findMany({
+      where: { ownerId: userId },
+      select: { id: true }
+    });
+    const businessIds = businesses.map(b => b.id);
+    const userByEmail = await this.prisma.user.findMany({
       where: {
+        businessId:{in:businessIds},
         email: {
-          contains: email, 
+          contains: email,
           mode: 'insensitive',
         },
       },
-      take: 10, // Limit to 10 results
+      take: 10, 
       select: {
         id: true,
         name: true,
@@ -77,5 +111,6 @@ export class UsersService {
         businessId: true,
       },
     });
+    return userByEmail
   }
 }

--- a/server/src/utils/toMinutes.ts
+++ b/server/src/utils/toMinutes.ts
@@ -1,0 +1,5 @@
+export function toMinutes(time: string): number {
+    const numbers = time.split(':').map(Number)
+    const minutes= numbers[0] * 60 + numbers[1]
+    return minutes
+}


### PR DESCRIPTION
## Summary

- **feat(utils)**: New shared `toMinutes(HH:MM)` utility used across bookings and schedules for time comparison.
- **feat(services)!**: All CRUD endpoints now validate that the authenticated admin owns the target business. `DELETE` and `PUT` routes changed from `/:id` to `/:businessId/:id`. `findAll` returns `BusinessWithServices[]` and is restricted to `ADMIN` only. `UpdateServiceDto` omits `businessId`.
- **feat(schedules)!**: `findAll`, `delete`, and `update` now filter/validate by `ownerId`. New `GET /schedules/:id` endpoint added. Time comparison fixed via `toMinutes()`.
- **feat(users)!**: `findAll`, `searchByEmail`, `delete`, and `update` scoped to the authenticated admin's business employees only.
- **fix(bookings)**: `remove()` renamed to `delete()` for consistency; booking lookup tightened with userId filter; uses shared `toMinutes()`.
- **fix(business)**: Missing `await` added to `create()`.
- **test**: All spec files updated to match new method signatures, `DeepMockProxy` standardized, fixtures corrected.

## Breaking Changes

| Module | Change |
|---|---|
| services | `DELETE/PUT /:id` → `/:businessId/:id`; `findAll` shape changed; CLIENT role removed |
| schedules | `findAll`, `delete`, `update` require ownership |
| users | `findAll` no longer global; `delete`/`update` scoped to owner's business |

## Test plan

- [ ] Run `npm test` in `server/` — all unit tests should pass
- [ ] Verify `GET /services` returns `BusinessWithServices[]` for ADMIN token
- [ ] Verify `DELETE /services/:businessId/:id` and `PUT /services/:businessId/:id` work correctly
- [ ] Verify `GET /schedules` returns only schedules for owned businesses
- [ ] Verify `GET /users` returns only employees of owned businesses
- [ ] Verify cross-business requests return 403