### PR TITLE
fix(client): API contract corrections, status machine and UX fixes v0.2.2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/client/src/components/bookingManagement/BookingForm.tsx
+++ b/client/src/components/bookingManagement/BookingForm.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import ServiceSelector from './ServiceSelector';
 import { useAuth } from '../../context/AuthContext';
-import axios from 'axios';
-
+import { apiClient } from '../../services/apiClient';
+import Input from '../ui/Input';
+import Select from '../ui/Select';
+import Button from '../ui/Button';
 
 interface Service {
   id: string;
@@ -23,8 +25,8 @@ interface BookingFormProps {
 export interface CreateBookingData {
   serviceId: string;
   businessId: string;
-  date: string;  // Format: "2025-07-18T18:00:00.000Z"
-  timezone: string;  // Format: "America/Argentina/Buenos_Aires"
+  date: string;
+  timezone: string;
   finalPrice: number;
   employeeId?: string;
   userId?: string;
@@ -38,6 +40,7 @@ export interface BookingData extends CreateBookingData {
   status: BookingStatus;
   createdAt: Date;
 }
+
 interface Employee {
   id: string;
   name: string;
@@ -45,7 +48,20 @@ interface Employee {
 
 type BookingStatus = 'PENDING' | 'CONFIRMED' | 'CANCELLED';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+function translateBookingError(msg: string): string {
+  if (!msg) return 'Error al crear la reserva';
+  if (/closing time|would end at/i.test(msg))
+    return 'El turno finalizaría después del horario de cierre. Elegí un horario más temprano.';
+  if (/No available employees/i.test(msg))
+    return 'No hay empleados disponibles en ese horario.';
+  if (/not available at the chosen time/i.test(msg))
+    return 'El empleado seleccionado no está disponible en ese horario.';
+  if (/Employee not found in this business/i.test(msg))
+    return 'El empleado no pertenece a este negocio.';
+  if (/required/i.test(msg) && !/negocio|atiende/i.test(msg))
+    return 'Completá todos los campos requeridos.';
+  return msg;
+}
 
 const BookingForm: React.FC<BookingFormProps> = ({
   onSubmit,
@@ -62,56 +78,61 @@ const BookingForm: React.FC<BookingFormProps> = ({
   const [availableEmployees, setAvailableEmployees] = useState<Employee[]>([]);
   const [selectedEmployeeId, setSelectedEmployeeId] = useState<string | null>(null);
   const [loadingEmployees, setLoadingEmployees] = useState(false);
-  const [employeeError, setEmployeeError] = useState<string | null>(null);
-  const effectiveBusinessId = role === 'CLIENT' ? selectedBusiness?.id : businessId;
+  const [businesses, setBusinesses] = useState<{ id: string; name: string; services: Service[] }[]>([]);
+
+  const [adminBusinesses, setAdminBusinesses] = useState<{ id: string; name: string }[]>([]);
+  const [adminSelectedBusinessId, setAdminSelectedBusinessId] = useState<string>('');
+
+  const needsAdminBusinessPicker = role === 'ADMIN' && !businessId;
+  const effectiveBusinessId =
+    role === 'CLIENT'      ? selectedBusiness?.id :
+    needsAdminBusinessPicker ? adminSelectedBusinessId || undefined :
+    businessId;
+
   const [bookingData, setBookingData] = useState<CreateBookingData>({
     serviceId: '',
     businessId: '',
-    date: new Date().toISOString().split('T')[0], // Just the date part initially
+    date: new Date().toISOString().split('T')[0],
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    finalPrice: 0
+    finalPrice: 0,
   });
-  const [businesses, setBusinesses] = useState<{ id: string; name: string; services: Service[] }[]>([]);
 
-  // Update bookingData when selectedService changes
   useEffect(() => {
     if (selectedService) {
       setBookingData(prev => ({
         ...prev,
         serviceId: selectedService.id,
         businessId: selectedService.businessId,
-        finalPrice: selectedService.price
+        finalPrice: selectedService.price,
       }));
     }
   }, [selectedService]);
-  // Fetch business info if role is CLIENT
+
   useEffect(() => {
     if (role !== 'CLIENT') return;
-
-    axios.get(`${API_BASE_URL}/business/public`, {
-      withCredentials: true,
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
-    })
-      .then(response => {
-        setBusinesses(response.data);
-      })
-      .catch(error => {
-        console.error('Error fetching business:', error);
-        setError('Failed to fetch business information');
-        setTimeout(() => setError(null), 5000);
-      });
+    apiClient.get('/business/public')
+      .then(res => setBusinesses(res.data))
+      .catch(() => setError('Error al cargar los negocios'));
   }, [role]);
+
+  useEffect(() => {
+    if (!needsAdminBusinessPicker) return;
+    apiClient.get('/business')
+      .then(res => {
+        setAdminBusinesses(res.data);
+        if (res.data.length > 0) setAdminSelectedBusinessId(res.data[0].id);
+      })
+      .catch(() => setError('Error al cargar los negocios'));
+  }, [needsAdminBusinessPicker]);
 
   useEffect(() => {
     if (!effectiveBusinessId || !selectedService || !bookingData.date || !startTime) {
       setAvailableEmployees([]);
       return;
-    };
+    }
     const [year, month, day] = bookingData.date.split('-').map(Number);
     const [hours, minutes] = startTime.split(':').map(Number);
-    const startDateTime = new Date(year, month - 1, day, hours, minutes)
+    const startDateTime = new Date(year, month - 1, day, hours, minutes);
     const endDateTime = new Date(startDateTime.getTime() + selectedService.durationMin * 60000);
 
     setLoadingEmployees(true);
@@ -120,20 +141,11 @@ const BookingForm: React.FC<BookingFormProps> = ({
       date: startDateTime.toISOString(),
       endTime: endDateTime.toISOString(),
     });
-    axios.get(`${API_BASE_URL}/bookings/available-employees?${params}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      }
+    apiClient.get(`/bookings/available-employees?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
     })
-      .then(response => {
-        setAvailableEmployees(response.data);
-      })
-      .catch(error => {
-        setAvailableEmployees([]);
-        console.error('Error fetching available employees:', error);
-        setEmployeeError('Failed to fetch available employees');
-        setTimeout(() => setEmployeeError(null), 5000);
-      })
+      .then(res => setAvailableEmployees(res.data))
+      .catch(() => setAvailableEmployees([]))
       .finally(() => setLoadingEmployees(false));
   }, [effectiveBusinessId, selectedService, bookingData.date, startTime, token]);
 
@@ -143,19 +155,18 @@ const BookingForm: React.FC<BookingFormProps> = ({
     setLoading(true);
 
     if (!token) {
-      setError('You must be logged in to create a booking');
+      setError('Debés iniciar sesión para crear una reserva');
       setLoading(false);
       return;
     }
 
     if (!selectedService || !bookingData.date || !startTime) {
-      setError('Please fill in all required fields');
+      setError('Completá todos los campos requeridos');
       setLoading(false);
       return;
     }
 
     try {
-      // Convert the date and time to an ISO string in the correct timezone
       const [year, month, day] = bookingData.date.split('-').map(Number);
       const [hours, minutes] = startTime.split(':').map(Number);
       const dateTime = new Date(year, month - 1, day, hours, minutes);
@@ -166,133 +177,124 @@ const BookingForm: React.FC<BookingFormProps> = ({
         date: dateTime.toISOString(),
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         finalPrice: selectedService.price,
-        ...(selectedEmployeeId && { employeeId: selectedEmployeeId})
+        ...(selectedEmployeeId && { employeeId: selectedEmployeeId }),
       };
 
       await onSubmit(submitData);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred while saving the booking');
+      const msg = err instanceof Error ? err.message : 'Error al crear la reserva';
+      setError(translateBookingError(msg));
     } finally {
       setLoading(false);
     }
   };
 
-
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
-      {/* Business selectior Only CLIENT */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {role === 'CLIENT' && (
-          <div className="col-span-2">
-            <label className="block text-sm font-medium text-gray-700">Select Business</label>
-            <select
-              value={selectedBusiness?.id || ''}
-              onChange={(e) => {
-                const business = businesses.find(b => b.id === e.target.value) || null;
-                setSelectedBusiness(business);
-                setSelectedService(null); // Reset selected service when business changes
-              }}
-              required
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-            >
-              <option value="">-- Seleccionar un negocio --</option>
-              {businesses.map(business => (
-                <option key={business.id} value={business.id}>{business.name}</option>
-              ))}
-            </select>
-          </div>
-        )}
-         {/*SERVICE SELECTOR  */}
-        <div className="col-span-2">
-          {role === 'CLIENT' ? (
-            <>
-              <label className="block text-sm font-medium text-gray-700">Servicio *</label>
-              <select
-                value={selectedService?.id || ''}
-                onChange={(e) => {
-                  const s = selectedBusiness?.services.find(s => s.id === e.target.value) || null;
-                  setSelectedService(s);
-                }}
-                disabled={!selectedBusiness}
-                required
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 disabled:opacity-50"
-              >
-                <option value="">Seleccionar servicio...</option>
-                {selectedBusiness?.services.map(s => (
-                  <option key={s.id} value={s.id}>{s.name} — ${s.price} ({s.durationMin} min)</option>
-                ))}
-              </select>
-            </>
-          ) : (
-            <ServiceSelector
-              businessId={businessId}
-              onServiceSelect={(service) => setSelectedService(service)}
-              selectedServiceId={bookingData.serviceId}
-            />
-          )}
-        </div>
-        {/* Date and time inputs */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Date</label>
-          <input
-            type="date"
-            name="date"
-            value={bookingData.date.split('T')[0]} // Extract only the date part from ISO string
-            onChange={(e) => setBookingData(prev => ({ ...prev, date: e.target.value }))}
-            required
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-          />
-        </div>
-        {/* Time input */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700">Start Time</label>
-          <input
-            type="time"
-            value={startTime}
-            onChange={(e) => setStartTime(e.target.value)}
-            required
-            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-          />
-        </div>
-        
-       
-        {/*Employee selection */}
-        <div className="col-span-2">
-          <label className="block text-sm font-medium text-gray-700">Select Employee (optional)</label>
-          {loadingEmployees ? (
-            <p>Loading available employees...Cargando empleados...</p>
-          ) : employeeError ? (
-            <p className="text-red-600">{employeeError}</p>
-          ) : (
-            <select
-              value={selectedEmployeeId || ''}
-              onChange={(e) => setSelectedEmployeeId(e.target.value || null)}
-              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-              disabled={!selectedService || !startTime || !bookingData.date}
-            >
-              <option value="">Cualquier empleado disponible</option>
-              {availableEmployees.map(emp => (
-                <option key={emp.id} value={emp.id}>{emp.name}</option>
-              ))}
-            </select>
-          )}
-
-        </div>
-      </div>
-      {error && (
-        <div className="text-red-600 text-sm mt-2">{error}</div>
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {/* Business selector — CLIENT only */}
+      {role === 'CLIENT' && (
+        <Select
+          label="Negocio"
+          value={selectedBusiness?.id || ''}
+          onChange={e => {
+            const biz = businesses.find(b => b.id === e.target.value) || null;
+            setSelectedBusiness(biz);
+            setSelectedService(null);
+          }}
+          required
+        >
+          <option value="">Seleccioná un negocio</option>
+          {businesses.map(b => (
+            <option key={b.id} value={b.id}>{b.name}</option>
+          ))}
+        </Select>
       )}
 
-      
-      {/* Employee selection is optional, only show if there are available employees */}
-      <div className="flex justify-end space-x-3">
-        <button
-          type="submit"
-          disabled={loading || !selectedService}
-          className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+      {/* Admin business picker — only when no businessId prop */}
+      {needsAdminBusinessPicker && (
+        <Select
+          label="Negocio"
+          value={adminSelectedBusinessId}
+          onChange={e => setAdminSelectedBusinessId(e.target.value)}
+          required
         >
-          {loading ? 'Saving...' : isEditing ? 'Update Booking' : 'Create Booking'}
-        </button>
+          <option value="">Seleccioná un negocio</option>
+          {adminBusinesses.map(b => (
+            <option key={b.id} value={b.id}>{b.name}</option>
+          ))}
+        </Select>
+      )}
+
+      {/* Service selector */}
+      {role === 'CLIENT' ? (
+        <Select
+          label="Servicio"
+          value={selectedService?.id || ''}
+          onChange={e => {
+            const s = selectedBusiness?.services.find(sv => sv.id === e.target.value) || null;
+            setSelectedService(s);
+          }}
+          disabled={!selectedBusiness}
+          required
+        >
+          <option value="">Seleccioná un servicio</option>
+          {selectedBusiness?.services.map(s => (
+            <option key={s.id} value={s.id}>
+              {s.name} — ${s.price} ({s.durationMin} min)
+            </option>
+          ))}
+        </Select>
+      ) : (
+        <ServiceSelector
+          businessId={businessId}
+          onServiceSelect={service => setSelectedService(service)}
+          selectedServiceId={bookingData.serviceId}
+        />
+      )}
+
+      {/* Date and time */}
+      <div className="grid grid-cols-2 gap-4">
+        <Input
+          label="Fecha"
+          type="date"
+          value={bookingData.date.split('T')[0]}
+          onChange={e => setBookingData(prev => ({ ...prev, date: e.target.value }))}
+          required
+        />
+        <Input
+          label="Hora de inicio"
+          type="time"
+          value={startTime}
+          onChange={e => setStartTime(e.target.value)}
+          required
+        />
+      </div>
+
+      {/* Employee selector */}
+      <Select
+        label="Empleado (opcional)"
+        value={selectedEmployeeId || ''}
+        onChange={e => setSelectedEmployeeId(e.target.value || null)}
+        disabled={loadingEmployees || !selectedService || !startTime || !bookingData.date}
+        hint={loadingEmployees ? 'Cargando empleados disponibles…' : undefined}
+      >
+        <option value="">Cualquier empleado disponible</option>
+        {availableEmployees.map(emp => (
+          <option key={emp.id} value={emp.id}>{emp.name}</option>
+        ))}
+      </Select>
+
+      {/* Inline error */}
+      {error && (
+        <div className="bg-danger-light border border-danger/30 text-danger-text text-sm px-4 py-3 rounded-lg">
+          {error}
+        </div>
+      )}
+
+      <div className="flex justify-end pt-2">
+        <Button type="submit" loading={loading} disabled={!selectedService}>
+          {isEditing ? 'Actualizar turno' : 'Crear turno'}
+        </Button>
       </div>
     </form>
   );

--- a/client/src/components/bookingManagement/BookingStatusButton.tsx
+++ b/client/src/components/bookingManagement/BookingStatusButton.tsx
@@ -1,64 +1,63 @@
 import { useState } from 'react';
 import { updateBookingStatus } from '../../services/bookingService';
+import Button from '../ui/Button';
 
 interface BookingStatusButtonProps {
-    bookingId: string;
-    currentStatus: string;
-    onStatusUpdate: () => void;
+  bookingId: string;
+  currentStatus: string;
+  onStatusUpdate: () => void;
 }
 
+type Transition = { label: string; next: string; variant: 'primary' | 'danger' | 'ghost' };
+
+const TRANSITIONS: Record<string, Transition[]> = {
+  PENDING: [
+    { label: 'Confirmar',  next: 'CONFIRMED', variant: 'primary' },
+    { label: 'Cancelar',   next: 'CANCELLED', variant: 'danger'  },
+  ],
+  CONFIRMED: [
+    { label: 'Completar',  next: 'COMPLETED', variant: 'primary' },
+    { label: 'Cancelar',   next: 'CANCELLED', variant: 'danger'  },
+  ],
+  COMPLETED: [],
+  CANCELLED: [],
+};
+
 const BookingStatusButton = ({ bookingId, currentStatus, onStatusUpdate }: BookingStatusButtonProps) => {
-    const [isLoading, setIsLoading] = useState(false);
+  const [loadingNext, setLoadingNext] = useState<string | null>(null);
 
-    const getNextStatus = (current: string) => {
-        switch (current) {
-            case 'PENDING':
-                return 'CONFIRMED';
-            case 'CONFIRMED':
-                return 'CANCELLED';
-            case 'CANCELLED':
-                return 'PENDING';
-            default:
-                return 'PENDING';
-        }
-    };
+  const transitions = TRANSITIONS[currentStatus] ?? [];
 
-    const getStatusColor = (status: string) => {
-        switch (status) {
-            case 'PENDING':
-                return 'bg-yellow-500';
-            case 'CONFIRMED':
-                return 'bg-green-500';
-            case 'CANCELLED':
-                return 'bg-red-500';
-            default:
-                return 'bg-gray-500';
-        }
-    };
+  if (transitions.length === 0) return null;
 
-    const handleStatusChange = async () => {
-        try {
-            setIsLoading(true);
-            const nextStatus = getNextStatus(currentStatus);
-            await updateBookingStatus(bookingId, nextStatus);
-            onStatusUpdate();
-        } catch (error) {
-            console.error('Error updating booking status:', error);
-            alert('Error al actualizar el estado de la reserva');
-        } finally {
-            setIsLoading(false);
-        }
-    };
+  const handleChange = async (next: string) => {
+    setLoadingNext(next);
+    try {
+      await updateBookingStatus(bookingId, next);
+      onStatusUpdate();
+    } catch {
+      // error is handled by caller's toast or console
+    } finally {
+      setLoadingNext(null);
+    }
+  };
 
-    return (
-        <button
-            onClick={handleStatusChange}
-            disabled={isLoading}
-            className={`px-4 py-2 rounded-md text-white ${getStatusColor(currentStatus)} ${isLoading ? 'opacity-50' : 'hover:opacity-80'}`}
+  return (
+    <div className="flex items-center gap-2">
+      {transitions.map(t => (
+        <Button
+          key={t.next}
+          size="sm"
+          variant={t.variant}
+          loading={loadingNext === t.next}
+          disabled={loadingNext !== null}
+          onClick={() => handleChange(t.next)}
         >
-            {isLoading ? 'Actualizando...' : currentStatus}
-        </button>
-    );
+          {t.label}
+        </Button>
+      ))}
+    </div>
+  );
 };
 
 export default BookingStatusButton;

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -403,7 +403,8 @@ const Admin: React.FC = () => {
               toast('Turno creado exitosamente', 'success');
               setShowBookingForm(false);
             } catch (err: any) {
-              toast(err.response?.data?.message || 'Error al crear el turno', 'error');
+              toast(err.message || 'Error al crear el turno', 'error');
+              throw err;
             }
           }}
         />

--- a/client/src/pages/bookings.tsx
+++ b/client/src/pages/bookings.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
-import axios from 'axios';
 import BookingForm, { type CreateBookingData } from '../components/bookingManagement/BookingForm';
 import { createBooking } from '../services/bookingService';
 import { useAuth } from '../context/AuthContext';
+import { apiClient } from '../services/apiClient';
 import BookingStatusButton from '../components/bookingManagement/BookingStatusButton';
 import StatusBadge, { bookingStatusVariant } from '../components/ui/StatusBadge';
 import { useToast } from '../components/ui/Toast';
@@ -15,20 +15,20 @@ interface Booking {
   finalPrice: number;
 }
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-
 const Bookings = () => {
-  const { token } = useAuth();
+  const { user } = useAuth();
   const { toast } = useToast();
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
 
   const fetchBookings = async () => {
+    const endpoint =
+      user?.role === 'ADMIN'    ? '/bookings' :
+      user?.role === 'EMPLOYEE' ? '/bookings/my-assignments' :
+                                  '/bookings/my-bookings';
     try {
-      const res = await axios.get(`${API_BASE_URL}/bookings/my-bookings`, {
-        headers: { Authorization: `Bearer ${token}` }
-      });
+      const res = await apiClient.get(endpoint);
       setBookings(res.data);
     } catch {
       toast('Error al cargar las reservas', 'error');
@@ -37,7 +37,7 @@ const Bookings = () => {
     }
   };
 
-  useEffect(() => { if (token) fetchBookings(); }, [token]);
+  useEffect(() => { if (user) fetchBookings(); }, [user]);
 
   const handleCreate = async (data: CreateBookingData) => {
     try {
@@ -47,6 +47,7 @@ const Bookings = () => {
       fetchBookings();
     } catch (err: any) {
       toast(err.message || 'Error al crear la reserva', 'error');
+      throw err;
     }
   };
 
@@ -68,7 +69,7 @@ const Bookings = () => {
       {showForm && (
         <div className="bg-surface rounded-xl shadow-card border border-border p-6 animate-fade-in">
           <h3 className="text-base font-semibold text-content mb-4">Nueva reserva</h3>
-          <BookingForm role="CLIENT" onSubmit={handleCreate} />
+          <BookingForm role={(user?.role as 'ADMIN' | 'CLIENT' | 'EMPLOYEE') ?? 'CLIENT'} onSubmit={handleCreate} />
         </div>
       )}
 

--- a/client/src/pages/business.tsx
+++ b/client/src/pages/business.tsx
@@ -41,7 +41,7 @@ const BusinessPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [editingBusiness, setEditingBusiness] = useState<Business | null>(null);
-  const [formData, setFormData] = useState<CreateBusinessDto>({ name: '', ownerId: user?.id || '' });
+  const [formData, setFormData] = useState<CreateBusinessDto>({ name: '' });
   const [submitting, setSubmitting] = useState(false);
 
   const [showServicesModal, setShowServicesModal] = useState(false);
@@ -50,10 +50,6 @@ const BusinessPage: React.FC = () => {
   const [showServiceForm, setShowServiceForm] = useState(false);
   const [serviceForm, setServiceForm] = useState({ name: '', description: '', price: '', durationMin: '' });
   const [serviceSubmitting, setServiceSubmitting] = useState(false);
-
-  useEffect(() => {
-    setFormData(prev => ({ ...prev, ownerId: user?.id || '' }));
-  }, [user?.id]);
 
   useEffect(() => { fetchBusinesses(); }, [user?.id]);
 
@@ -66,13 +62,13 @@ const BusinessPage: React.FC = () => {
 
   const openCreate = () => {
     setEditingBusiness(null);
-    setFormData({ name: '', ownerId: user?.id || '' });
+    setFormData({ name: '' });
     setShowModal(true);
   };
 
   const openEdit = (b: Business) => {
     setEditingBusiness(b);
-    setFormData({ name: b.name, ownerId: b.ownerId });
+    setFormData({ name: b.name });
     setShowModal(true);
   };
 
@@ -142,7 +138,7 @@ const BusinessPage: React.FC = () => {
   const handleDeleteService = async (serviceId: string) => {
     if (!window.confirm('¿Eliminar este servicio?')) return;
     try {
-      await serviceService.delete(serviceId);
+      await serviceService.delete(serviceId, selectedBusiness!.id);
       setBusinessServices(prev => prev.filter(s => s.id !== serviceId));
       toast('Servicio eliminado', 'success');
     } catch (err: any) {

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -68,16 +68,14 @@ const Calendar: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
-      const start = viewDays[0].toISOString().slice(0, 10);
-      const end   = viewDays[viewDays.length - 1].toISOString().slice(0, 10);
-      const res   = await apiClient.get(`/bookings/my-bookings?from=${start}&to=${end}`);
+      const res = await apiClient.get('/bookings');
       setBookings(res.data);
     } catch {
       setError('No se pudieron cargar los turnos');
     } finally {
       setLoading(false);
     }
-  }, [token, currentDate, viewMode]);
+  }, [token]);
 
   useEffect(() => { fetchBookings(); }, [fetchBookings]);
 
@@ -228,15 +226,15 @@ const Calendar: React.FC = () => {
                       />
                     ))}
                     {/* Booking chips */}
-                    {dayBookings.map(b => (
+                    {dayBookings.filter(b => b.service && b.date && b.endTime).map(b => (
                       <button
                         key={b.id}
                         className={`absolute rounded-md border text-xs font-medium text-left px-1.5 py-1 overflow-hidden transition-opacity hover:opacity-80 ${statusColors[b.status] ?? 'bg-surface-3 text-content'}`}
                         style={chipStyle(b)}
                         onClick={() => setSelectedBooking(b)}
                       >
-                        <div className="truncate font-semibold">{b.service.name}</div>
-                        <div className="truncate opacity-75">{b.user.name}</div>
+                        <div className="truncate font-semibold">{b.service?.name ?? '—'}</div>
+                        <div className="truncate opacity-75">{b.user?.name ?? '—'}</div>
                       </button>
                     ))}
                   </div>
@@ -258,8 +256,8 @@ const Calendar: React.FC = () => {
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <div>
-                <h3 className="font-semibold text-content">{selectedBooking.service.name}</h3>
-                <p className="text-sm text-content-3">{selectedBooking.business.name}</p>
+                <h3 className="font-semibold text-content">{selectedBooking.service?.name ?? '—'}</h3>
+                <p className="text-sm text-content-3">{selectedBooking.business?.name ?? '—'}</p>
               </div>
               <StatusBadge
                 label={selectedBooking.status}
@@ -269,7 +267,7 @@ const Calendar: React.FC = () => {
             <dl className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <dt className="text-content-3">Cliente</dt>
-                <dd className="font-medium text-content">{selectedBooking.user.name}</dd>
+                <dd className="font-medium text-content">{selectedBooking.user?.name ?? '—'}</dd>
               </div>
               {selectedBooking.employee && (
                 <div className="flex justify-between">
@@ -289,13 +287,15 @@ const Calendar: React.FC = () => {
                   {new Date(selectedBooking.endTime).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
                 </dd>
               </div>
-              <div className="flex justify-between">
-                <dt className="text-content-3">Duración</dt>
-                <dd className="font-medium text-content">{selectedBooking.service.durationMin} min</dd>
-              </div>
+              {selectedBooking.service && (
+                <div className="flex justify-between">
+                  <dt className="text-content-3">Duración</dt>
+                  <dd className="font-medium text-content">{selectedBooking.service.durationMin} min</dd>
+                </div>
+              )}
               <div className="flex justify-between">
                 <dt className="text-content-3">Precio</dt>
-                <dd className="font-bold text-content">${selectedBooking.finalPrice.toLocaleString('es-AR')}</dd>
+                <dd className="font-bold text-content">${selectedBooking.finalPrice?.toLocaleString('es-AR') ?? '—'}</dd>
               </div>
             </dl>
           </div>

--- a/client/src/pages/services.tsx
+++ b/client/src/pages/services.tsx
@@ -139,7 +139,7 @@ const Services: React.FC = () => {
                     <td className="px-4 py-3 font-medium text-content">{s.name}</td>
                     <td className="px-4 py-3 text-content-2">{getBusinessName(s.businessId)}</td>
                     <td className="px-4 py-3 text-content-2">{s.durationMin} min</td>
-                    <td className="px-4 py-3 font-medium text-content">${s.price.toLocaleString('es-AR')}</td>
+                    <td className="px-4 py-3 font-medium text-content">${s.price != null ? s.price.toLocaleString('es-AR') : '—'}</td>
                     <td className="px-4 py-3 text-content-3 max-w-xs truncate">{s.description || '—'}</td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-2">

--- a/client/src/pages/services.tsx
+++ b/client/src/pages/services.tsx
@@ -76,7 +76,8 @@ const Services: React.FC = () => {
     setSubmitting(true);
     try {
       if (editingService) {
-        await serviceService.update(editingService.id, formData);
+        const { businessId, ...updateData } = formData;
+        await serviceService.update(editingService.id, businessId, updateData);
         toast('Servicio actualizado', 'success');
       } else {
         await serviceService.create(formData);
@@ -93,8 +94,10 @@ const Services: React.FC = () => {
 
   const handleDelete = async (id: string) => {
     if (!window.confirm('¿Eliminar este servicio?')) return;
+    const svc = services.find(s => s.id === id);
+    if (!svc) return;
     try {
-      await serviceService.delete(id);
+      await serviceService.delete(id, svc.businessId);
       setServices(prev => prev.filter(s => s.id !== id));
       toast('Servicio eliminado', 'success');
     } catch (err: any) {

--- a/client/src/services/businessService.ts
+++ b/client/src/services/businessService.ts
@@ -27,10 +27,9 @@ export interface Business {
 }
 
 /**
- * DTO para crear negocio: solo nombre y UUID del dueño
+ * DTO para crear negocio: solo nombre (el backend toma el ownerId del JWT)
  */
 export interface CreateBusinessDto {
-  ownerId: string;
   name: string;
 }
 
@@ -115,8 +114,8 @@ export const serviceService = {
     return response.data;
   },
 
-  async delete(id: string): Promise<Service> {
-    const response = await apiClient.delete(`/services/${id}`);
+  async delete(serviceId: string, businessId: string): Promise<Service> {
+    const response = await apiClient.delete(`/services/${businessId}/${serviceId}`);
     return response.data;
   },
 };

--- a/client/src/services/serviceService.ts
+++ b/client/src/services/serviceService.ts
@@ -28,8 +28,8 @@ export interface UpdateServiceDto {
 
 export const serviceService = {
   async getAll(): Promise<Service[]> {
-    const response = await apiClient.get('/services');
-    return response.data;
+    const response = await apiClient.get<{ name: string; services: Service[] }[]>('/services');
+    return response.data.flatMap(biz => biz.services);
   },
 
   async create(data: CreateServiceDto): Promise<Service> {
@@ -37,13 +37,13 @@ export const serviceService = {
     return response.data;
   },
 
-  async update(id: string, data: UpdateServiceDto): Promise<Service> {
-    const response = await apiClient.put(`/services/${id}`, data);
+  async update(id: string, businessId: string, data: Omit<UpdateServiceDto, 'businessId'>): Promise<Service> {
+    const response = await apiClient.put(`/services/${businessId}/${id}`, data);
     return response.data;
   },
 
-  async delete(id: string): Promise<Service> {
-    const response = await apiClient.delete(`/services/${id}`);
+  async delete(id: string, businessId: string): Promise<Service> {
+    const response = await apiClient.delete(`/services/${businessId}/${id}`);
     return response.data;
   },
 };


### PR DESCRIPTION
## Summary

- **API contracts**: Remove `ownerId` from business create DTO (backend derives it from JWT); flatten `BusinessWithServices[]` response in `serviceService.getAll()`; fix update/delete service URLs to include `businessId` (`/services/:businessId/:id`)
- **Booking state machine**: `COMPLETED` and `CANCELLED` are now terminal states — no more cycling back. Valid transitions: `PENDING → CONFIRMED | CANCELLED`, `CONFIRMED → COMPLETED | CANCELLED`
- **BookingForm**: Admin users now see their own businesses (via `GET /business`) instead of the public list when creating a booking without a pre-selected business. Added Spanish error translation and design system styling
- **Calendar**: Null safety guards on `service`, `user`, and `business` relations to prevent crashes on bookings with deleted references
- **Bookings page**: Uses role-appropriate endpoint (`ADMIN → /bookings`, `EMPLOYEE → /bookings/my-assignments`, `CLIENT → /bookings/my-bookings`) and passes the real user role to `BookingForm`
- **Admin**: Fixed error propagation on booking creation (`err.message` instead of `err.response?.data?.message`)

## Test plan

- [x] Crear negocio desde `/business` — no debe dar error de `ownerId`
- [x] Cargar servicios desde `/services` — tabla no queda en blanco
- [x] Editar y eliminar un servicio — URLs correctas con `businessId`
- [x] Calendar — navegar semanas sin crash de null reference
- [x] Cambiar estado de turno: confirmar que COMPLETED y CANCELLED no tienen botones de transición
- [x] Admin crea turno desde `/bookings` — ve sus propios negocios
- [x] Error de horario fuera de rango muestra mensaje en español en el formulario
