### PR TITLE
feat(client): UI/UX redesign v0.3.0 — dashboards, calendar, login and navigation

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -8,14 +8,8 @@ interface NavItem {
   to: string;
   label: string;
   icon: React.ReactNode;
-  roles?: Array<'ADMIN' | 'CLIENT' | 'EMPLOYEE'>;
 }
 
-const CalendarIcon = () => (
-  <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
-    <rect x="3" y="4" width="18" height="18" rx="2" /><path strokeLinecap="round" d="M16 2v4M8 2v4M3 10h18" />
-  </svg>
-);
 const HomeIcon = () => (
   <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
     <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
@@ -24,11 +18,6 @@ const HomeIcon = () => (
 const UsersIcon = () => (
   <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
     <path strokeLinecap="round" strokeLinejoin="round" d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" /><circle cx="9" cy="7" r="4" /><path strokeLinecap="round" d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" />
-  </svg>
-);
-const BriefcaseIcon = () => (
-  <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
-    <rect x="2" y="7" width="20" height="14" rx="2" /><path strokeLinecap="round" d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
   </svg>
 );
 const ScissorsIcon = () => (
@@ -46,6 +35,21 @@ const BookmarkIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2v16z" />
   </svg>
 );
+const ChartIcon = () => (
+  <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+  </svg>
+);
+const CalendarIcon = () => (
+  <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
+    <rect x="3" y="4" width="18" height="18" rx="2" /><path strokeLinecap="round" d="M16 2v4M8 2v4M3 10h18" />
+  </svg>
+);
+const HistoryIcon = () => (
+  <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+);
 const ChevronIcon = ({ flipped }: { flipped?: boolean }) => (
   <svg
     width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"
@@ -60,17 +64,24 @@ const LogoutIcon = () => (
   </svg>
 );
 
-const navItems: NavItem[] = [
-  { to: '/dashboard/admin',    label: 'Dashboard',  icon: <HomeIcon />,      roles: ['ADMIN'] },
-  { to: '/dashboard/employee', label: 'Dashboard',  icon: <HomeIcon />,      roles: ['EMPLOYEE'] },
-  { to: '/dashboard',          label: 'Dashboard',  icon: <HomeIcon />,      roles: ['CLIENT'] },
-  { to: '/calendar',           label: 'Calendario', icon: <CalendarIcon />,  roles: ['ADMIN', 'EMPLOYEE'] },
-  { to: '/bookings',           label: 'Turnos',     icon: <BookmarkIcon />,  roles: ['ADMIN', 'CLIENT', 'EMPLOYEE'] },
-  { to: '/services',           label: 'Servicios',  icon: <ScissorsIcon />,  roles: ['ADMIN'] },
-  { to: '/schedules',          label: 'Horarios',   icon: <ClockIcon />,     roles: ['ADMIN'] },
-  { to: '/business',           label: 'Negocio',    icon: <BriefcaseIcon />, roles: ['ADMIN'] },
-  { to: '/users',              label: 'Usuarios',   icon: <UsersIcon />,     roles: ['ADMIN'] },
-];
+const navByRole: Record<string, NavItem[]> = {
+  ADMIN: [
+    { to: '/dashboard/admin', label: 'Dashboard',  icon: <HomeIcon /> },
+    { to: '/users',           label: 'Empleados',  icon: <UsersIcon /> },
+    { to: '/bookings',        label: 'Reservas',   icon: <BookmarkIcon /> },
+    { to: '/services',        label: 'Servicios',  icon: <ScissorsIcon /> },
+    { to: '/schedules',       label: 'Horarios',   icon: <ClockIcon /> },
+    { to: '/calendar',        label: 'Calendario', icon: <CalendarIcon /> },
+  ],
+  EMPLOYEE: [
+    { to: '/dashboard/employee', label: 'Mis Turnos', icon: <HomeIcon /> },
+    { to: '/bookings',           label: 'Historial',  icon: <HistoryIcon /> },
+  ],
+  CLIENT: [
+    { to: '/dashboard', label: 'Mis Reservas', icon: <HomeIcon /> },
+    { to: '/bookings',  label: 'Reservar',     icon: <BookmarkIcon /> },
+  ],
+};
 
 const Sidebar: React.FC = () => {
   const { user, logout } = useAuth();
@@ -83,10 +94,7 @@ const Sidebar: React.FC = () => {
     navigate('/home');
   };
 
-  const visibleItems = navItems.filter(
-    item => !item.roles || (user && item.roles.includes(user.role))
-  );
-
+  const visibleItems: NavItem[] = user ? (navByRole[user.role] ?? []) : [];
   const isActive = (to: string) => location.pathname === to;
 
   const sidebarContent = (
@@ -116,7 +124,7 @@ const Sidebar: React.FC = () => {
       <nav className="flex-1 py-3 overflow-y-auto">
         {visibleItems.map(item => (
           <Link
-            key={item.to}
+            key={item.to + item.label}
             to={item.to}
             onClick={() => setMobileOpen(false)}
             title={compact ? item.label : undefined}

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -35,11 +35,6 @@ const BookmarkIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2v16z" />
   </svg>
 );
-const ChartIcon = () => (
-  <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-  </svg>
-);
 const CalendarIcon = () => (
   <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
     <rect x="3" y="4" width="18" height="18" rx="2" /><path strokeLinecap="round" d="M16 2v4M8 2v4M3 10h18" />

--- a/client/src/components/ui/Avatar.tsx
+++ b/client/src/components/ui/Avatar.tsx
@@ -12,6 +12,14 @@ const sizeClasses = {
   lg: 'w-12 h-12 text-base',
 };
 
+const colorClasses = [
+  'bg-primary-light text-primary',
+  'bg-success-light text-success',
+  'bg-warning-light text-warning',
+  'bg-info-light text-info',
+  'bg-danger-light text-danger',
+];
+
 const initials = (name: string) =>
   name
     .split(' ')
@@ -20,12 +28,18 @@ const initials = (name: string) =>
     .join('')
     .toUpperCase();
 
+const colorFromName = (name: string) => {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash += name.charCodeAt(i);
+  return colorClasses[hash % colorClasses.length];
+};
+
 const Avatar: React.FC<AvatarProps> = ({ name, size = 'md', className = '' }) => (
   <div
     className={`
       inline-flex items-center justify-center rounded-full font-semibold
-      bg-primary-light text-primary select-none shrink-0
-      ${sizeClasses[size]} ${className}
+      select-none shrink-0
+      ${colorFromName(name)} ${sizeClasses[size]} ${className}
     `}
     aria-label={name}
   >

--- a/client/src/components/ui/StatCard.tsx
+++ b/client/src/components/ui/StatCard.tsx
@@ -5,6 +5,7 @@ interface StatCardProps {
   value: string | number;
   icon: React.ReactNode;
   trend?: { value: number; label: string };
+  subtitle?: string;
   accent?: 'primary' | 'success' | 'warning' | 'danger' | 'info';
   className?: string;
 }
@@ -22,6 +23,7 @@ const StatCard: React.FC<StatCardProps> = ({
   value,
   icon,
   trend,
+  subtitle,
   accent = 'primary',
   className = '',
 }) => (
@@ -32,6 +34,7 @@ const StatCard: React.FC<StatCardProps> = ({
     <div className="flex-1 min-w-0">
       <p className="text-xs font-medium text-content-3 uppercase tracking-wider mb-1">{label}</p>
       <p className="text-2xl font-bold text-content leading-tight">{value}</p>
+      {subtitle && <p className="text-xs text-content-3 mt-0.5">{subtitle}</p>}
       {trend && (
         <p className={`text-xs mt-1 font-medium ${trend.value >= 0 ? 'text-success' : 'text-danger'}`}>
           {trend.value >= 0 ? '↑' : '↓'} {Math.abs(trend.value)}% {trend.label}

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -1,18 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
+import { apiClient } from '../services/apiClient';
 import { createBooking } from '../services/bookingService';
 import BookingForm from '../components/bookingManagement/BookingForm';
 import type { Business } from '../services/businessService';
-import type { Employee } from '../services/userService';
 import StatCard from '../components/ui/StatCard';
+import StatusBadge, { bookingStatusVariant } from '../components/ui/StatusBadge';
 import Modal from '../components/ui/Modal';
 import Button from '../components/ui/Button';
-import Input from '../components/ui/Input';
-import Select from '../components/ui/Select';
 import { useToast } from '../components/ui/Toast';
-
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 const TurnosIcon = () => (
   <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
@@ -29,156 +25,111 @@ const UsersIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" /><circle cx="9" cy="7" r="4" /><path strokeLinecap="round" d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" />
   </svg>
 );
-const PlusIcon = () => (
-  <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14m-7-7h14" />
-  </svg>
-);
-const EditIcon = () => (
-  <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-  </svg>
-);
-const TrashIcon = () => (
-  <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+const TodayIcon = () => (
+  <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
+    <rect x="3" y="4" width="18" height="18" rx="2" /><path strokeLinecap="round" d="M16 2v4M8 2v4M3 10h18M8 14h.01M12 14h.01" />
   </svg>
 );
 
+interface BarChartProps {
+  data: { period: string; totalBookings: number }[];
+}
+
+const BarChart: React.FC<BarChartProps> = ({ data }) => {
+  if (!data.length) {
+    return <p className="text-sm text-content-3 text-center py-8">Sin datos para el período</p>;
+  }
+  const max = Math.max(...data.map(d => d.totalBookings), 1);
+  return (
+    <div className="flex items-end justify-around gap-1.5 h-36 pt-2">
+      {data.map(d => (
+        <div key={d.period} className="flex flex-col items-center gap-1.5 flex-1 min-w-0">
+          <span className="text-xs font-semibold text-content-2">{d.totalBookings || ''}</span>
+          <div
+            className="w-full bg-primary rounded-t-md transition-all duration-500 min-h-[4px]"
+            style={{ height: `${Math.max((d.totalBookings / max) * 100, d.totalBookings > 0 ? 8 : 4)}px` }}
+          />
+          <span className="text-xs text-content-3 truncate w-full text-center">{d.period}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+interface RecentBooking {
+  id: string;
+  date: string;
+  status: string;
+  finalPrice: number;
+  service?: { name: string };
+  user?: { name: string };
+}
+
 const Admin: React.FC = () => {
-  const { user, token } = useAuth();
+  const { user } = useAuth();
   const { toast } = useToast();
 
   const [businesses, setBusinesses] = useState<Business[]>([]);
   const [selectedBusiness, setSelectedBusiness] = useState('');
-  const [employees, setEmployees] = useState<Employee[]>([]);
   const [totalEmployees, setTotalEmployees] = useState(0);
-  const [search, setSearch] = useState('');
-  const [page, setPage] = useState(1);
-  const limit = 10;
-  const [loadingEmployees, setLoadingEmployees] = useState(false);
-  const [groupBy, setGroupBy] = useState<'day' | 'month' | 'year'>('month');
 
-  const [showEmployeeForm, setShowEmployeeForm] = useState(false);
-  const [newEmployee, setNewEmployee] = useState({ name: '', email: '', password: '', businessId: '' });
-  const [employeeLoading, setEmployeeLoading] = useState(false);
-
-  const [editEmployee, setEditEmployee] = useState<any | null>(null);
-  const [editEmployeeLoading, setEditEmployeeLoading] = useState(false);
+  const [metrics, setMetrics] = useState<{ totalBookings: number; totalRevenue: number; bookingsByGroup: { period: string; totalBookings: number; totalRevenue: number }[] } | null>(null);
+  const [todayCount, setTodayCount] = useState(0);
+  const [recentBookings, setRecentBookings] = useState<RecentBooking[]>([]);
 
   const [showBookingForm, setShowBookingForm] = useState(false);
 
-  const [metrics, setMetrics] = useState<any>(null);
-  const [metricsError, setMetricsError] = useState<string | null>(null);
-  const [fromDate, setFromDate] = useState(() => {
-    const t = new Date();
-    return new Date(t.getFullYear(), t.getMonth(), 1).toISOString().slice(0, 10);
-  });
-  const [toDate, setToDate] = useState(() => {
-    const t = new Date();
-    return new Date(t.getFullYear(), t.getMonth() + 1, 0).toISOString().slice(0, 10);
-  });
-
   useEffect(() => {
-    if (!user || !token) return;
-    axios.get(`${API_BASE_URL}/admin/me`, { headers: { Authorization: `Bearer ${token}` } })
+    if (!user) return;
+    apiClient.get('/admin/me')
       .then(res => {
         const biz = res.data.businesses || [];
         setBusinesses(biz);
-        if (biz.length > 0) {
-          setSelectedBusiness(biz[0].id);
-          setNewEmployee(e => ({ ...e, businessId: biz[0].id }));
-        }
+        if (biz.length > 0) setSelectedBusiness(biz[0].id);
       })
       .catch(() => setBusinesses([]));
-  }, [user, token]);
+  }, [user]);
 
-  const fetchMetrics = async (businessId: string, from: string, to: string, userId: string | undefined, gb: string) => {
-    let fromParam = from, toParam = to;
-    if (gb === 'year')  { fromParam = from.slice(0, 4); toParam = to.slice(0, 4); }
-    if (gb === 'month') { fromParam = from.slice(0, 7); toParam = to.slice(0, 7); }
+  const fetchData = useCallback(async (businessId: string) => {
+    if (!businessId) return;
+
+    const today = new Date().toISOString().slice(0, 10);
+    const year = today.slice(0, 4);
+    const yearFrom = `${year}-01`;
+    const yearTo   = `${year}-12`;
+
     try {
-      const res = await axios.get(`${API_BASE_URL}/admin/metrics`, {
-        params: { businessId, userId, from: fromParam, to: toParam, groupBy: gb },
-        headers: { Authorization: `Bearer ${token}` }
-      });
-      setMetrics(res.data);
-      setMetricsError(null);
-    } catch (err: any) {
-      setMetricsError(err.response?.data?.message || 'Error al cargar las métricas');
+      const [metricsRes, todayRes, employeesRes, bookingsRes] = await Promise.allSettled([
+        apiClient.get('/admin/metrics', {
+          params: { businessId, userId: user?.id, from: yearFrom, to: yearTo, groupBy: 'month' },
+        }),
+        apiClient.get('/admin/metrics', {
+          params: { businessId, userId: user?.id, from: today, to: today, groupBy: 'day' },
+        }),
+        apiClient.get('/admin/employees', { params: { businessId, page: 1, limit: 1 } }),
+        apiClient.get('/bookings'),
+      ]);
+
+      if (metricsRes.status === 'fulfilled') setMetrics(metricsRes.value.data);
+      if (todayRes.status === 'fulfilled') {
+        const groups = todayRes.value.data?.bookingsByGroup ?? [];
+        setTodayCount(groups[0]?.totalBookings ?? 0);
+      }
+      if (employeesRes.status === 'fulfilled') setTotalEmployees(employeesRes.value.data.total ?? 0);
+      if (bookingsRes.status === 'fulfilled') {
+        const sorted = [...bookingsRes.value.data]
+          .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+          .slice(0, 5);
+        setRecentBookings(sorted);
+      }
+    } catch {
+      // individual errors handled via allSettled
     }
-  };
+  }, [user?.id]);
 
   useEffect(() => {
-    if (!selectedBusiness) return;
-    fetchMetrics(selectedBusiness, fromDate, toDate, user?.id, groupBy);
-  }, [selectedBusiness, fromDate, toDate, groupBy]);
-
-  const fetchEmployees = async () => {
-    if (!selectedBusiness) return;
-    setLoadingEmployees(true);
-    try {
-      const res = await axios.get(`${API_BASE_URL}/admin/employees`, {
-        params: { businessId: selectedBusiness, search, page, limit },
-        headers: { Authorization: `Bearer ${token}` }
-      });
-      setEmployees(res.data.employees);
-      setTotalEmployees(res.data.total);
-    } catch (err: any) {
-      toast(err.response?.data?.message || 'Error al obtener empleados', 'error');
-    } finally {
-      setLoadingEmployees(false);
-    }
-  };
-
-  useEffect(() => { fetchEmployees(); }, [selectedBusiness, search, page, token]);
-
-  const handleCreateEmployee = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setEmployeeLoading(true);
-    try {
-      await axios.post(`${API_BASE_URL}/admin/employee`, { ...newEmployee, role: 'EMPLOYEE', authProvider: 'LOCAL' }, { headers: { Authorization: `Bearer ${token}` } });
-      toast('Empleado creado exitosamente', 'success');
-      setShowEmployeeForm(false);
-      setNewEmployee({ name: '', email: '', password: '', businessId: selectedBusiness });
-      fetchEmployees();
-    } catch (err: any) {
-      toast(err.response?.data?.message || 'Error al crear el empleado', 'error');
-    } finally {
-      setEmployeeLoading(false);
-    }
-  };
-
-  const handleDeleteEmployee = async (id: string) => {
-    if (!window.confirm('¿Seguro que deseas eliminar este empleado?')) return;
-    try {
-      await axios.delete(`${API_BASE_URL}/admin/employee/${id}`, { headers: { Authorization: `Bearer ${token}` } });
-      setEmployees(prev => prev.filter(a => a.id !== id));
-      setTotalEmployees(prev => prev - 1);
-      toast('Empleado eliminado', 'success');
-    } catch {
-      toast('Error al eliminar empleado', 'error');
-    }
-  };
-
-  const handleEditEmployee = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setEditEmployeeLoading(true);
-    try {
-      await axios.put(`${API_BASE_URL}/admin/employee/${editEmployee.id}`, {
-        name: editEmployee.name, email: editEmployee.email, password: editEmployee.password || undefined
-      }, { headers: { Authorization: `Bearer ${token}` } });
-      toast('Empleado actualizado', 'success');
-      setEmployees(prev => prev.map(a => a.id === editEmployee.id ? { ...a, name: editEmployee.name, email: editEmployee.email } : a));
-      setEditEmployee(null);
-    } catch (err: any) {
-      toast(err.response?.data?.message || 'Error al actualizar empleado', 'error');
-    } finally {
-      setEditEmployeeLoading(false);
-    }
-  };
-
-  const totalPages = Math.max(1, Math.ceil(totalEmployees / limit));
+    if (selectedBusiness) fetchData(selectedBusiness);
+  }, [selectedBusiness, fetchData]);
 
   return (
     <div className="space-y-6">
@@ -198,14 +149,14 @@ const Admin: React.FC = () => {
 
       {businesses.length === 0 && (
         <div className="bg-warning-light border border-warning/30 text-warning-text px-4 py-3 rounded-xl text-sm">
-          No tienes negocios asignados. Crea un negocio primero.
+          No tenés negocios asignados. Creá un negocio primero.
         </div>
       )}
 
-      {/* Metrics stat cards */}
-      <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+      {/* 4 stat cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <StatCard
-          label="Total de turnos"
+          label="Total reservas"
           value={metrics?.totalBookings ?? '—'}
           icon={<TurnosIcon />}
           accent="primary"
@@ -221,176 +172,64 @@ const Admin: React.FC = () => {
           value={totalEmployees}
           icon={<UsersIcon />}
           accent="warning"
-          className="col-span-2 lg:col-span-1"
+        />
+        <StatCard
+          label="Hoy"
+          value={todayCount}
+          subtitle="Turnos agendados"
+          icon={<TodayIcon />}
+          accent="info"
         />
       </div>
 
-      {/* Metrics filters + table */}
-      <div className="bg-surface rounded-xl shadow-card border border-border p-5">
-        <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
-          <h2 className="text-base font-semibold text-content">Turnos por período</h2>
-          <div className="flex items-center gap-2 flex-wrap">
-            <Select
-              value={groupBy}
-              onChange={e => setGroupBy(e.target.value as 'day' | 'month' | 'year')}
-              className="w-28"
-            >
-              <option value="day">Día</option>
-              <option value="month">Mes</option>
-              <option value="year">Año</option>
-            </Select>
-            <input
-              type={groupBy === 'day' ? 'date' : groupBy === 'month' ? 'month' : 'number'}
-              value={fromDate}
-              onChange={e => setFromDate(e.target.value)}
-              min={groupBy === 'year' ? '2000' : undefined}
-              max={groupBy === 'year' ? '2100' : undefined}
-              className="rounded-lg border border-border px-3 py-1.5 text-sm bg-surface focus:outline-none focus:ring-2 focus:ring-primary/40"
-            />
-            <input
-              type={groupBy === 'day' ? 'date' : groupBy === 'month' ? 'month' : 'number'}
-              value={toDate}
-              onChange={e => setToDate(e.target.value)}
-              min={groupBy === 'year' ? '2000' : undefined}
-              max={groupBy === 'year' ? '2100' : undefined}
-              className="rounded-lg border border-border px-3 py-1.5 text-sm bg-surface focus:outline-none focus:ring-2 focus:ring-primary/40"
-            />
-            <Button size="sm" onClick={() => fetchMetrics(selectedBusiness, fromDate, toDate, user?.id, groupBy)}>
-              Buscar
+      {/* Charts + Recent bookings */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-5">
+        {/* Bar chart */}
+        <div className="lg:col-span-3 bg-surface rounded-xl shadow-card border border-border p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-base font-semibold text-content">Turnos por mes</h3>
+            <Button size="sm" variant="secondary" onClick={() => fetchData(selectedBusiness)}>
+              Actualizar
             </Button>
           </div>
+          <BarChart data={metrics?.bookingsByGroup ?? []} />
         </div>
-        {metricsError && <p className="text-sm text-danger-text mb-3">{metricsError}</p>}
-        <div className="overflow-x-auto rounded-lg border border-border">
-          <table className="w-full text-sm">
-            <thead className="bg-surface-2">
-              <tr>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Período</th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Turnos</th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Ingresos</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {metrics?.bookingsByGroup?.length > 0 ? metrics.bookingsByGroup.map((g: any) => (
-                <tr key={g.period} className="hover:bg-surface-2 transition-colors">
-                  <td className="px-4 py-3 font-medium text-content">{g.period}</td>
-                  <td className="px-4 py-3 text-content-2">{g.totalBookings}</td>
-                  <td className="px-4 py-3 text-content-2">${g.totalRevenue?.toLocaleString('es-AR')}</td>
-                </tr>
-              )) : (
-                <tr><td colSpan={3} className="px-4 py-8 text-center text-content-3">Sin datos para el período</td></tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
 
-      {/* Employee management */}
-      <div className="bg-surface rounded-xl shadow-card border border-border p-5">
-        <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
-          <h2 className="text-base font-semibold text-content">Empleados</h2>
-          <div className="flex items-center gap-2">
-            <Button size="sm" variant="secondary" onClick={() => setShowBookingForm(true)}>
-              Crear turno
-            </Button>
-            <Button size="sm" leftIcon={<PlusIcon />} onClick={() => setShowEmployeeForm(true)}>
-              Nuevo empleado
+        {/* Recent bookings */}
+        <div className="lg:col-span-2 bg-surface rounded-xl shadow-card border border-border p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-base font-semibold text-content">Reservas recientes</h3>
+            <Button size="sm" onClick={() => setShowBookingForm(true)}>
+              + Nueva
             </Button>
           </div>
-        </div>
-
-        {/* Search */}
-        <Input
-          placeholder="Buscar por nombre o email…"
-          value={search}
-          onChange={e => { setSearch(e.target.value); setPage(1); }}
-          wrapperClassName="mb-4 max-w-72"
-          leftIcon={
-            <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <circle cx="11" cy="11" r="8" /><path strokeLinecap="round" d="M21 21l-4.35-4.35" />
-            </svg>
-          }
-        />
-
-        <div className="overflow-x-auto rounded-lg border border-border">
-          <table className="w-full text-sm">
-            <thead className="bg-surface-2">
-              <tr>
-                {['Nombre', 'Email', 'Negocio', 'Creado', 'Acciones'].map(h => (
-                  <th key={h} className="px-4 py-2.5 text-left text-xs font-medium text-content-3 uppercase tracking-wider">{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {loadingEmployees ? (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-content-3">Cargando…</td></tr>
-              ) : employees.length === 0 ? (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-content-3">No hay empleados</td></tr>
-              ) : employees.map(emp => (
-                <tr key={emp.id} className="hover:bg-surface-2 transition-colors">
-                  <td className="px-4 py-3 font-medium text-content">{emp.name}</td>
-                  <td className="px-4 py-3 text-content-2">{emp.email}</td>
-                  <td className="px-4 py-3 text-content-2">{emp.businessName || '—'}</td>
-                  <td className="px-4 py-3 text-content-3">{new Date(emp.createdAt).toLocaleDateString('es-AR')}</td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <button
-                        onClick={() => handleDeleteEmployee(emp.id)}
-                        className="w-7 h-7 flex items-center justify-center rounded-md text-danger hover:bg-danger-light transition-colors"
-                        aria-label="Eliminar"
-                      ><TrashIcon /></button>
-                      <button
-                        onClick={() => setEditEmployee({ ...emp, password: '' })}
-                        className="w-7 h-7 flex items-center justify-center rounded-md text-content-2 hover:bg-surface-3 transition-colors"
-                        aria-label="Editar"
-                      ><EditIcon /></button>
-                    </div>
-                  </td>
-                </tr>
+          {recentBookings.length === 0 ? (
+            <p className="text-sm text-content-3 text-center py-8">Sin reservas</p>
+          ) : (
+            <div className="divide-y divide-border">
+              {recentBookings.map(b => (
+                <div key={b.id} className="py-3 flex items-center justify-between gap-3">
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-content truncate">
+                      {b.service?.name ?? '—'}
+                    </p>
+                    <p className="text-xs text-content-3">
+                      {new Date(b.date).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
+                      {b.user?.name ? ` · ${b.user.name}` : ''}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <StatusBadge label={b.status} variant={bookingStatusVariant(b.status)} />
+                    <span className="text-sm font-semibold text-content">
+                      ${b.finalPrice?.toLocaleString('es-AR')}
+                    </span>
+                  </div>
+                </div>
               ))}
-            </tbody>
-          </table>
-        </div>
-
-        {/* Pagination */}
-        <div className="flex items-center justify-between mt-4 text-sm text-content-2">
-          <span>Página {page} de {totalPages}</span>
-          <div className="flex gap-2">
-            <Button size="sm" variant="secondary" disabled={page === 1} onClick={() => setPage(p => p - 1)}>Anterior</Button>
-            <Button size="sm" variant="secondary" disabled={page === totalPages || totalEmployees === 0} onClick={() => setPage(p => p + 1)}>Siguiente</Button>
-          </div>
+            </div>
+          )}
         </div>
       </div>
-
-      {/* Create employee modal */}
-      <Modal open={showEmployeeForm} onClose={() => setShowEmployeeForm(false)} title="Nuevo empleado" size="sm">
-        <form onSubmit={handleCreateEmployee} className="flex flex-col gap-4">
-          {businesses.length > 1 && (
-            <Select label="Negocio" value={newEmployee.businessId} onChange={e => setNewEmployee(p => ({ ...p, businessId: e.target.value }))} required>
-              {businesses.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
-            </Select>
-          )}
-          <Input label="Nombre" value={newEmployee.name} onChange={e => setNewEmployee(p => ({ ...p, name: e.target.value }))} required />
-          <Input label="Email" type="email" value={newEmployee.email} onChange={e => setNewEmployee(p => ({ ...p, email: e.target.value }))} required />
-          <Input label="Contraseña" type="password" value={newEmployee.password} onChange={e => setNewEmployee(p => ({ ...p, password: e.target.value }))} required />
-          <div className="flex gap-2 pt-2">
-            <Button type="submit" loading={employeeLoading} className="flex-1">Crear empleado</Button>
-            <Button type="button" variant="secondary" onClick={() => setShowEmployeeForm(false)} className="flex-1">Cancelar</Button>
-          </div>
-        </form>
-      </Modal>
-
-      {/* Edit employee modal */}
-      <Modal open={!!editEmployee} onClose={() => setEditEmployee(null)} title="Editar empleado" size="sm">
-        {editEmployee && (
-          <form onSubmit={handleEditEmployee} className="flex flex-col gap-4">
-            <Input label="Nombre" value={editEmployee.name} onChange={e => setEditEmployee((p: any) => ({ ...p, name: e.target.value }))} required />
-            <Input label="Email" type="email" value={editEmployee.email} onChange={e => setEditEmployee((p: any) => ({ ...p, email: e.target.value }))} required />
-            <Input label="Nueva contraseña (opcional)" type="password" value={editEmployee.password} onChange={e => setEditEmployee((p: any) => ({ ...p, password: e.target.value }))} />
-            <Button type="submit" loading={editEmployeeLoading}>Guardar cambios</Button>
-          </form>
-        )}
-      </Modal>
 
       {/* Create booking modal */}
       <Modal open={showBookingForm} onClose={() => setShowBookingForm(false)} title="Crear turno">
@@ -402,6 +241,7 @@ const Admin: React.FC = () => {
               await createBooking({ ...bookingData, businessId: selectedBusiness });
               toast('Turno creado exitosamente', 'success');
               setShowBookingForm(false);
+              fetchData(selectedBusiness);
             } catch (err: any) {
               toast(err.message || 'Error al crear el turno', 'error');
               throw err;

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -1,9 +1,12 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { apiClient } from '../services/apiClient';
+import { createBooking } from '../services/bookingService';
+import BookingForm from '../components/bookingManagement/BookingForm';
 import StatusBadge, { bookingStatusVariant } from '../components/ui/StatusBadge';
 import Button from '../components/ui/Button';
 import Modal from '../components/ui/Modal';
+import { useToast } from '../components/ui/Toast';
 
 interface CalendarBooking {
   id: string;
@@ -11,67 +14,153 @@ interface CalendarBooking {
   endTime: string;
   status: string;
   finalPrice: number;
-  service: { name: string; durationMin: number };
-  business: { name: string };
-  employee?: { name: string } | null;
-  user: { name: string };
+  service: { name: string; durationMin: number } | null;
+  business: { name: string } | null;
+  employee?: { id: string; name: string } | null;
+  user: { name: string } | null;
 }
 
 type ViewMode = 'week' | 'day';
 
-const HOURS = Array.from({ length: 14 }, (_, i) => i + 8); // 08:00 - 21:00
+const HOURS    = Array.from({ length: 14 }, (_, i) => i + 8); // 08–21
+const CELL_H   = 56; // px per hour
+const MONTH_NAMES = ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
+const DAY_S    = ['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'];
+const DAY_L    = ['Domingo','Lunes','Martes','Miércoles','Jueves','Viernes','Sábado'];
 
-const formatHour = (h: number) => `${String(h).padStart(2, '0')}:00`;
+// Employee color palette using design system tokens
+const PALETTE = [
+  { chip: 'bg-success-light border-success text-success-text',  av: 'bg-success-light text-success',  dot: 'bg-success'  },
+  { chip: 'bg-info-light border-info text-info-text',           av: 'bg-info-light text-info',         dot: 'bg-info'     },
+  { chip: 'bg-primary-light border-primary text-primary',       av: 'bg-primary-light text-primary',   dot: 'bg-primary'  },
+  { chip: 'bg-warning-light border-warning text-warning-text',  av: 'bg-warning-light text-warning',   dot: 'bg-warning'  },
+  { chip: 'bg-danger-light border-danger text-danger-text',     av: 'bg-danger-light text-danger',     dot: 'bg-danger'   },
+];
 
-const getWeekDays = (base: Date): Date[] => {
-  const monday = new Date(base);
-  const day = monday.getDay();
-  const diff = day === 0 ? -6 : 1 - day;
-  monday.setDate(monday.getDate() + diff);
-  return Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(monday);
-    d.setDate(monday.getDate() + i);
-    return d;
-  });
-};
+const initials = (name: string) =>
+  name.split(' ').slice(0, 2).map(w => w[0]).join('').toUpperCase();
 
-const minutesSinceMidnight = (iso: string) => {
+const isSameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
+
+const msm = (iso: string) => {
   const d = new Date(iso);
   return d.getHours() * 60 + d.getMinutes();
 };
 
-const DAY_NAMES_SHORT = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
-const DAY_NAMES_LONG  = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
-const MONTH_NAMES     = ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
-
-const statusColors: Record<string, string> = {
-  CONFIRMED: 'bg-success-light border-success text-success-text',
-  PENDING:   'bg-warning-light border-warning text-warning-text',
-  CANCELLED: 'bg-danger-light  border-danger  text-danger-text',
-  COMPLETED: 'bg-info-light    border-info    text-info-text',
+const getWeekDays = (base: Date): Date[] => {
+  const mon = new Date(base);
+  const diff = mon.getDay() === 0 ? -6 : 1 - mon.getDay();
+  mon.setDate(mon.getDate() + diff);
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(mon);
+    d.setDate(mon.getDate() + i);
+    return d;
+  });
 };
 
+// ── Mini calendar ────────────────────────────────────────────────────────────
+const MiniCalendar: React.FC<{ selected: Date; onSelect: (d: Date) => void }> = ({ selected, onSelect }) => {
+  const [month, setMonth] = useState(() =>
+    new Date(selected.getFullYear(), selected.getMonth(), 1)
+  );
+  const today = new Date();
+  const daysInMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate();
+  const firstDow    = new Date(month.getFullYear(), month.getMonth(), 1).getDay();
+  const blanks      = firstDow === 0 ? 6 : firstDow - 1;
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center justify-between mb-3">
+        <button
+          onClick={() => setMonth(m => new Date(m.getFullYear(), m.getMonth() - 1, 1))}
+          className="w-6 h-6 flex items-center justify-center rounded hover:bg-surface-3 text-content-3 transition-colors"
+        >
+          <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" d="M15 19l-7-7 7-7"/>
+          </svg>
+        </button>
+        <span className="text-sm font-semibold text-content">
+          {MONTH_NAMES[month.getMonth()]} {month.getFullYear()}
+        </span>
+        <button
+          onClick={() => setMonth(m => new Date(m.getFullYear(), m.getMonth() + 1, 1))}
+          className="w-6 h-6 flex items-center justify-center rounded hover:bg-surface-3 text-content-3 transition-colors"
+        >
+          <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" d="M9 5l7 7-7 7"/>
+          </svg>
+        </button>
+      </div>
+
+      <div className="grid grid-cols-7 text-center mb-1">
+        {['L','M','M','J','V','S','D'].map((d, i) => (
+          <div key={i} className="text-xs text-content-3 font-medium py-0.5">{d}</div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 text-center gap-y-0.5">
+        {Array(blanks).fill(null).map((_, i) => <div key={`b${i}`} />)}
+        {Array.from({ length: daysInMonth }, (_, i) => i + 1).map(day => {
+          const d      = new Date(month.getFullYear(), month.getMonth(), day);
+          const isTod  = isSameDay(d, today);
+          const isSel  = isSameDay(d, selected);
+          return (
+            <button
+              key={day}
+              onClick={() => onSelect(d)}
+              className={`h-7 w-7 mx-auto rounded-full text-xs flex items-center justify-center transition-colors font-medium
+                ${isSel  ? 'bg-primary text-content-inverse' :
+                  isTod  ? 'bg-primary-light text-primary' :
+                           'hover:bg-surface-3 text-content-2'}`}
+            >
+              {day}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// ── Main component ───────────────────────────────────────────────────────────
 const Calendar: React.FC = () => {
   const { token } = useAuth();
-  const [bookings, setBookings] = useState<CalendarBooking[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<ViewMode>('week');
-  const [currentDate, setCurrentDate] = useState(new Date());
-  const [selectedBooking, setSelectedBooking] = useState<CalendarBooking | null>(null);
+  const { toast } = useToast();
 
-  const weekDays = getWeekDays(currentDate);
-  const viewDays = viewMode === 'week' ? weekDays : [currentDate];
+  const [bookings,      setBookings]      = useState<CalendarBooking[]>([]);
+  const [employees,     setEmployees]     = useState<{ id: string; name: string }[]>([]);
+  const [businessId,    setBusinessId]    = useState<string>('');
+  const [loading,       setLoading]       = useState(true);
+  const [viewMode,      setViewMode]      = useState<ViewMode>('day');
+  const [currentDate,   setCurrentDate]   = useState(new Date());
+  const [filterEmpId,   setFilterEmpId]   = useState<string | null>(null);
+  const [selectedBkg,   setSelectedBkg]   = useState<CalendarBooking | null>(null);
+  const [showNewBkg,    setShowNewBkg]    = useState(false);
+
+  // Fetch business + employees for this admin
+  useEffect(() => {
+    if (!token) return;
+    apiClient.get('/admin/me').then(res => {
+      const biz = res.data.businesses?.[0];
+      if (!biz) return;
+      setBusinessId(biz.id);
+      apiClient.get('/admin/employees', { params: { businessId: biz.id, page: 1, limit: 200 } })
+        .then(r => {
+          const list = (r.data.employees ?? r.data.data ?? r.data) as { id: string; name: string }[];
+          setEmployees(Array.isArray(list) ? list : []);
+        })
+        .catch(() => {});
+    }).catch(() => {});
+  }, [token]);
 
   const fetchBookings = useCallback(async () => {
     if (!token) return;
     setLoading(true);
-    setError(null);
     try {
       const res = await apiClient.get('/bookings');
       setBookings(res.data);
     } catch {
-      setError('No se pudieron cargar los turnos');
+      toast('No se pudieron cargar los turnos', 'error');
     } finally {
       setLoading(false);
     }
@@ -79,6 +168,68 @@ const Calendar: React.FC = () => {
 
   useEffect(() => { fetchBookings(); }, [fetchBookings]);
 
+  // Stable color index map for fetched employees
+  const colorMap = useMemo(() => {
+    const m = new Map<string, number>();
+    employees.forEach((emp, i) => m.set(emp.id, i % PALETTE.length));
+    return m;
+  }, [employees]);
+
+  const pal = (empId?: string | null) => PALETTE[colorMap.get(empId ?? '') ?? 0];
+
+  // Stats
+  const todayStr  = new Date().toISOString().slice(0, 10);
+  const todayBkgs = useMemo(() =>
+    bookings
+      .filter(b => new Date(b.date).toISOString().slice(0, 10) === todayStr)
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()),
+    [bookings]
+  );
+  const pendingCount = bookings.filter(b => b.status === 'PENDING').length;
+
+  // Set of this business's employee IDs for fast lookup
+  const bizEmpIds = useMemo(() => new Set(employees.map(e => e.id)), [employees]);
+
+  // Per-employee booking count (only bookings assigned to a business employee)
+  const empCount = useMemo(() => {
+    const m = new Map<string, number>();
+    bookings.forEach(b => {
+      if (b.employee?.id && bizEmpIds.has(b.employee.id))
+        m.set(b.employee.id, (m.get(b.employee.id) ?? 0) + 1);
+    });
+    return m;
+  }, [bookings, bizEmpIds]);
+
+  // Filtered bookings — only employees from this business, then optionally by selected employee
+  const visibleBkgs = useMemo(() => {
+    const base = bizEmpIds.size > 0
+      ? bookings.filter(b => !b.employee?.id || bizEmpIds.has(b.employee.id))
+      : bookings;
+    return filterEmpId ? base.filter(b => b.employee?.id === filterEmpId) : base;
+  }, [bookings, bizEmpIds, filterEmpId]);
+
+  const bkgsForDay = useCallback((day: Date) => {
+    const iso = day.toISOString().slice(0, 10);
+    return visibleBkgs.filter(b => new Date(b.date).toISOString().slice(0, 10) === iso);
+  }, [visibleBkgs]);
+
+  // Day view: unique employees with bookings on currentDate
+  const dayColEmps = useMemo(() => {
+    const iso  = currentDate.toISOString().slice(0, 10);
+    const seen = new Set<string>();
+    const list: { id: string; name: string }[] = [];
+    visibleBkgs
+      .filter(b => new Date(b.date).toISOString().slice(0, 10) === iso && b.employee?.id)
+      .forEach(b => {
+        if (!seen.has(b.employee!.id)) {
+          seen.add(b.employee!.id);
+          list.push({ id: b.employee!.id, name: b.employee!.name });
+        }
+      });
+    return list;
+  }, [visibleBkgs, currentDate]);
+
+  // Navigation
   const navigate = (dir: 1 | -1) => {
     const d = new Date(currentDate);
     if (viewMode === 'week') d.setDate(d.getDate() + dir * 7);
@@ -86,220 +237,399 @@ const Calendar: React.FC = () => {
     setCurrentDate(d);
   };
 
-  const bookingsForDay = (day: Date) => {
-    const iso = day.toISOString().slice(0, 10);
-    return bookings.filter(b => new Date(b.date).toISOString().slice(0, 10) === iso);
-  };
+  const weekDays = getWeekDays(currentDate);
 
+  // Chip positioning
   const chipStyle = (b: CalendarBooking): React.CSSProperties => {
-    const start     = minutesSinceMidnight(b.date);
-    const end       = minutesSinceMidnight(b.endTime);
-    const dayStart  = 8 * 60;
-    const topPct    = ((start - dayStart) / (14 * 60)) * 100;
-    const heightPct = ((end - start) / (14 * 60)) * 100;
+    const start    = msm(b.date);
+    const end      = msm(b.endTime);
+    const dayStart = 8 * 60;
+    const total    = HOURS.length * 60;
     return {
-      top:    `${topPct}%`,
-      height: `max(${heightPct}%, 2.5rem)`,
+      top:    `${((start - dayStart) / total) * 100}%`,
+      height: `max(${((end - start) / total) * 100}%, 2.5rem)`,
       left: '2px', right: '2px',
     };
   };
 
   const headerLabel = () => {
     if (viewMode === 'week') {
-      const start = weekDays[0];
-      const end   = weekDays[6];
-      return `${start.getDate()} – ${end.getDate()} ${MONTH_NAMES[end.getMonth()]} ${end.getFullYear()}`;
+      const s = weekDays[0], e = weekDays[6];
+      return `${s.getDate()} – ${e.getDate()} ${MONTH_NAMES[e.getMonth()]} ${e.getFullYear()}`;
     }
-    return `${DAY_NAMES_LONG[currentDate.getDay()]} ${currentDate.getDate()} de ${MONTH_NAMES[currentDate.getMonth()]} ${currentDate.getFullYear()}`;
+    const d = currentDate;
+    return `${DAY_L[d.getDay()]}, ${d.getDate()} ${MONTH_NAMES[d.getMonth()].toLowerCase()} ${d.getFullYear()}`;
   };
 
-  const isToday = (d: Date) => {
-    const t = new Date();
-    return d.toDateString() === t.toDateString();
-  };
-
-  const CELL_HEIGHT = 56; // px per hour
+  // Hour label helper
+  const hLabel = (h: number) => `${String(h).padStart(2, '0')}:00`;
 
   return (
-    <div className="flex flex-col h-full gap-4">
-      {/* Toolbar */}
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => navigate(-1)}
-            className="w-8 h-8 flex items-center justify-center rounded-lg border border-border hover:bg-surface-3 transition-colors text-content-2"
-          >
-            <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-          </button>
-          <span className="text-sm font-semibold text-content min-w-52 text-center">{headerLabel()}</span>
-          <button
-            onClick={() => navigate(1)}
-            className="w-8 h-8 flex items-center justify-center rounded-lg border border-border hover:bg-surface-3 transition-colors text-content-2"
-          >
-            <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-            </svg>
-          </button>
-          <Button variant="ghost" size="sm" onClick={() => setCurrentDate(new Date())}>
-            Hoy
-          </Button>
-        </div>
-        <div className="flex rounded-lg border border-border overflow-hidden text-sm">
-          {(['week', 'day'] as ViewMode[]).map(m => (
-            <button
-              key={m}
-              onClick={() => setViewMode(m)}
-              className={`px-4 py-1.5 font-medium transition-colors ${
-                viewMode === m ? 'bg-primary text-content-inverse' : 'bg-surface text-content-2 hover:bg-surface-3'
-              }`}
-            >
-              {m === 'week' ? 'Semana' : 'Día'}
-            </button>
-          ))}
-        </div>
-      </div>
+    <div className="flex gap-4 h-full min-h-0">
 
-      {error && (
-        <div className="bg-danger-light border border-danger/30 text-danger-text px-4 py-3 rounded-lg text-sm">
-          {error}
-        </div>
-      )}
+      {/* ── Left panel ─────────────────────────────────────────────── */}
+      <aside className="w-60 shrink-0 bg-surface rounded-xl shadow-card border border-border flex flex-col overflow-y-auto">
+        {/* Mini calendar */}
+        <MiniCalendar
+          selected={currentDate}
+          onSelect={d => { setCurrentDate(d); setViewMode('day'); }}
+        />
 
-      {/* Calendar grid */}
-      <div className="flex-1 bg-surface rounded-xl shadow-card border border-border overflow-hidden flex flex-col min-h-0">
-        {/* Day headers */}
-        <div className={`grid border-b border-border ${viewMode === 'week' ? 'grid-cols-[4rem_repeat(7,1fr)]' : 'grid-cols-[4rem_1fr]'}`}>
-          <div className="h-12 border-r border-border" />
-          {viewDays.map(day => (
-            <div
-              key={day.toISOString()}
-              className={`h-12 flex flex-col items-center justify-center border-r border-border last:border-r-0 text-xs
-                ${isToday(day) ? 'bg-primary-light' : ''}`}
-            >
-              <span className="text-content-3 uppercase tracking-wider">
-                {DAY_NAMES_SHORT[day.getDay()]}
-              </span>
-              <span className={`font-bold text-sm ${isToday(day) ? 'text-primary' : 'text-content'}`}>
-                {day.getDate()}
-              </span>
-            </div>
-          ))}
-        </div>
-
-        {/* Scrollable grid body */}
-        <div className="flex-1 overflow-y-auto">
-          {loading ? (
-            <div className="flex items-center justify-center h-40 text-content-3 text-sm">
-              Cargando turnos...
-            </div>
+        {/* Today's bookings */}
+        <div className="border-t border-border p-4">
+          <p className="text-xs font-bold text-content-3 uppercase tracking-wider mb-3">
+            Hoy — {todayBkgs.length} turnos
+          </p>
+          {todayBkgs.length === 0 ? (
+            <p className="text-xs text-content-3">Sin turnos hoy</p>
           ) : (
-            <div
-              className={`grid ${viewMode === 'week' ? 'grid-cols-[4rem_repeat(7,1fr)]' : 'grid-cols-[4rem_1fr]'}`}
-              style={{ height: `${CELL_HEIGHT * HOURS.length}px` }}
-            >
-              {/* Hour labels */}
-              <div className="border-r border-border relative">
-                {HOURS.map(h => (
-                  <div
-                    key={h}
-                    className="absolute w-full flex items-start justify-center"
-                    style={{ top: `${(h - 8) * CELL_HEIGHT}px`, height: `${CELL_HEIGHT}px` }}
-                  >
-                    <span className="text-xs text-content-3 mt-1">{formatHour(h)}</span>
-                  </div>
-                ))}
-              </div>
-
-              {/* Day columns */}
-              {viewDays.map(day => {
-                const dayBookings = bookingsForDay(day);
+            <div className="space-y-1">
+              {todayBkgs.map(b => {
+                const p = pal(b.employee?.id);
                 return (
-                  <div key={day.toISOString()} className="relative border-r border-border last:border-r-0">
-                    {/* Hour grid lines */}
-                    {HOURS.map(h => (
-                      <div
-                        key={h}
-                        className="absolute w-full border-b border-border/50"
-                        style={{ top: `${(h - 8) * CELL_HEIGHT}px`, height: `${CELL_HEIGHT}px` }}
-                      />
-                    ))}
-                    {/* Booking chips */}
-                    {dayBookings.filter(b => b.service && b.date && b.endTime).map(b => (
-                      <button
-                        key={b.id}
-                        className={`absolute rounded-md border text-xs font-medium text-left px-1.5 py-1 overflow-hidden transition-opacity hover:opacity-80 ${statusColors[b.status] ?? 'bg-surface-3 text-content'}`}
-                        style={chipStyle(b)}
-                        onClick={() => setSelectedBooking(b)}
-                      >
-                        <div className="truncate font-semibold">{b.service?.name ?? '—'}</div>
-                        <div className="truncate opacity-75">{b.user?.name ?? '—'}</div>
-                      </button>
-                    ))}
-                  </div>
+                  <button
+                    key={b.id}
+                    onClick={() => setSelectedBkg(b)}
+                    className="w-full text-left flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-surface-2 transition-colors"
+                  >
+                    <div className={`w-1 self-stretch rounded-full shrink-0 ${p.dot}`} />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs font-medium text-content truncate">
+                        {b.user?.name ?? 'Walk-in'}
+                      </p>
+                      <p className="text-xs text-content-3">
+                        {new Date(b.date).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
+                      </p>
+                    </div>
+                  </button>
                 );
               })}
             </div>
           )}
         </div>
+
+        {/* Employee filter */}
+        <div className="border-t border-border p-4 flex-1">
+          <p className="text-xs font-bold text-content-3 uppercase tracking-wider mb-3">Empleados</p>
+          <div className="space-y-0.5">
+            <button
+              onClick={() => setFilterEmpId(null)}
+              className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-colors
+                ${filterEmpId === null ? 'bg-primary text-content-inverse' : 'hover:bg-surface-2 text-content-2'}`}
+            >
+              Todos
+            </button>
+            {employees.map(emp => {
+              const p = pal(emp.id);
+              return (
+                <button
+                  key={emp.id}
+                  onClick={() => setFilterEmpId(filterEmpId === emp.id ? null : emp.id)}
+                  className={`w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-xs transition-colors
+                    ${filterEmpId === emp.id ? 'bg-surface-3' : 'hover:bg-surface-2'}`}
+                >
+                  <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0 ${p.av}`}>
+                    {initials(emp.name)}
+                  </div>
+                  <span className="flex-1 text-left font-medium text-content truncate">{emp.name}</span>
+                  <span className="text-content-3">{empCount.get(emp.id) ?? 0}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </aside>
+
+      {/* ── Main area ──────────────────────────────────────────────── */}
+      <div className="flex-1 min-w-0 flex flex-col bg-surface rounded-xl shadow-card border border-border overflow-hidden">
+
+        {/* Toolbar */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-border shrink-0 flex-wrap gap-3">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-bold text-content">{headerLabel()}</span>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => navigate(-1)}
+                className="w-7 h-7 flex items-center justify-center rounded-lg border border-border hover:bg-surface-3 text-content-3 transition-colors"
+              >
+                <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" d="M15 19l-7-7 7-7"/>
+                </svg>
+              </button>
+              <button
+                onClick={() => navigate(1)}
+                className="w-7 h-7 flex items-center justify-center rounded-lg border border-border hover:bg-surface-3 text-content-3 transition-colors"
+              >
+                <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" d="M9 5l7 7-7 7"/>
+                </svg>
+              </button>
+            </div>
+            <div className="flex rounded-lg border border-border overflow-hidden text-xs">
+              {(['week', 'day'] as ViewMode[]).map(m => (
+                <button
+                  key={m}
+                  onClick={() => setViewMode(m)}
+                  className={`px-3 py-1.5 font-medium transition-colors
+                    ${viewMode === m ? 'bg-primary text-content-inverse' : 'bg-surface text-content-2 hover:bg-surface-3'}`}
+                >
+                  {m === 'week' ? 'Semana' : 'Día'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-content-3 bg-surface-2 px-2.5 py-1 rounded-full border border-border">
+              {bookings.length} Total
+            </span>
+            <span className="text-xs font-medium text-primary bg-primary-light px-2.5 py-1 rounded-full">
+              {todayBkgs.length} Hoy
+            </span>
+            <span className="text-xs font-medium text-warning-text bg-warning-light px-2.5 py-1 rounded-full">
+              {pendingCount} Pendientes
+            </span>
+            <Button size="sm" onClick={() => setShowNewBkg(true)}>
+              + Nuevo turno
+            </Button>
+          </div>
+        </div>
+
+        {/* Grid */}
+        <div className="flex-1 overflow-hidden flex flex-col">
+          {loading ? (
+            <div className="flex-1 flex items-center justify-center text-content-3 text-sm">Cargando turnos…</div>
+          ) : viewMode === 'day' ? (
+
+            /* ── DAY VIEW: columns = employees ── */
+            <div className="flex flex-col h-full overflow-hidden">
+              {dayColEmps.length === 0 ? (
+                <div className="flex-1 flex items-center justify-center text-content-3 text-sm">
+                  Sin turnos para este día
+                </div>
+              ) : (
+                <>
+                  {/* Employee headers */}
+                  <div
+                    className="grid shrink-0 border-b border-border"
+                    style={{ gridTemplateColumns: `4rem repeat(${dayColEmps.length}, 1fr)` }}
+                  >
+                    <div className="h-16 border-r border-border" />
+                    {dayColEmps.map(emp => {
+                      const p = pal(emp.id);
+                      const cnt = bkgsForDay(currentDate).filter(b => b.employee?.id === emp.id).length;
+                      return (
+                        <div key={emp.id} className="h-16 flex flex-col items-center justify-center border-r border-border last:border-r-0 gap-0.5">
+                          <div className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold ${p.av}`}>
+                            {initials(emp.name)}
+                          </div>
+                          <p className="text-xs font-semibold text-content">{emp.name}</p>
+                          <p className="text-xs text-content-3">{cnt} {cnt === 1 ? 'turno' : 'turnos'}</p>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {/* Scrollable grid body */}
+                  <div className="flex-1 overflow-y-auto">
+                    <div
+                      className="grid"
+                      style={{
+                        gridTemplateColumns: `4rem repeat(${dayColEmps.length}, 1fr)`,
+                        height: `${CELL_H * HOURS.length}px`,
+                      }}
+                    >
+                      {/* Hour labels */}
+                      <div className="border-r border-border relative">
+                        {HOURS.map(h => (
+                          <div
+                            key={h}
+                            className="absolute w-full flex items-start justify-center"
+                            style={{ top: `${(h - 8) * CELL_H}px`, height: `${CELL_H}px` }}
+                          >
+                            <span className="text-xs text-content-3 mt-1">{hLabel(h)}</span>
+                          </div>
+                        ))}
+                      </div>
+
+                      {/* Employee columns */}
+                      {dayColEmps.map(emp => {
+                        const p = pal(emp.id);
+                        const colBkgs = bkgsForDay(currentDate)
+                          .filter(b => b.employee?.id === emp.id && b.service && b.date && b.endTime);
+                        return (
+                          <div key={emp.id} className="relative border-r border-border last:border-r-0">
+                            {HOURS.map(h => (
+                              <div
+                                key={h}
+                                className="absolute w-full border-b border-border/40"
+                                style={{ top: `${(h - 8) * CELL_H}px`, height: `${CELL_H}px` }}
+                              />
+                            ))}
+                            {colBkgs.map(b => (
+                              <button
+                                key={b.id}
+                                className={`absolute rounded-md border text-xs font-medium text-left px-1.5 py-1 overflow-hidden hover:opacity-80 transition-opacity ${p.chip}`}
+                                style={chipStyle(b)}
+                                onClick={() => setSelectedBkg(b)}
+                              >
+                                <div className="truncate font-semibold">
+                                  {new Date(b.date).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
+                                  {' '}{b.service?.name}
+                                </div>
+                                <div className="truncate opacity-75">{b.user?.name ?? 'Walk-in'}</div>
+                              </button>
+                            ))}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+
+          ) : (
+
+            /* ── WEEK VIEW: columns = days ── */
+            <div className="flex flex-col h-full overflow-hidden">
+              <div
+                className="grid shrink-0 border-b border-border"
+                style={{ gridTemplateColumns: '4rem repeat(7, 1fr)' }}
+              >
+                <div className="h-12 border-r border-border" />
+                {weekDays.map(day => (
+                  <button
+                    key={day.toISOString()}
+                    onClick={() => { setCurrentDate(day); setViewMode('day'); }}
+                    className={`h-12 flex flex-col items-center justify-center border-r border-border last:border-r-0 text-xs
+                      ${isSameDay(day, new Date()) ? 'bg-primary-light' : 'hover:bg-surface-2'} transition-colors`}
+                  >
+                    <span className="text-content-3 uppercase tracking-wider">{DAY_S[day.getDay()]}</span>
+                    <span className={`font-bold text-sm ${isSameDay(day, new Date()) ? 'text-primary' : 'text-content'}`}>
+                      {day.getDate()}
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="flex-1 overflow-y-auto">
+                <div
+                  className="grid"
+                  style={{ gridTemplateColumns: '4rem repeat(7, 1fr)', height: `${CELL_H * HOURS.length}px` }}
+                >
+                  <div className="border-r border-border relative">
+                    {HOURS.map(h => (
+                      <div
+                        key={h}
+                        className="absolute w-full flex items-start justify-center"
+                        style={{ top: `${(h - 8) * CELL_H}px`, height: `${CELL_H}px` }}
+                      >
+                        <span className="text-xs text-content-3 mt-1">{hLabel(h)}</span>
+                      </div>
+                    ))}
+                  </div>
+                  {weekDays.map(day => {
+                    const dayB = bkgsForDay(day).filter(b => b.service && b.date && b.endTime);
+                    return (
+                      <div key={day.toISOString()} className="relative border-r border-border last:border-r-0">
+                        {HOURS.map(h => (
+                          <div
+                            key={h}
+                            className="absolute w-full border-b border-border/40"
+                            style={{ top: `${(h - 8) * CELL_H}px`, height: `${CELL_H}px` }}
+                          />
+                        ))}
+                        {dayB.map(b => {
+                          const p = pal(b.employee?.id);
+                          return (
+                            <button
+                              key={b.id}
+                              className={`absolute rounded-md border text-xs font-medium text-left px-1.5 py-1 overflow-hidden hover:opacity-80 transition-opacity ${p.chip}`}
+                              style={chipStyle(b)}
+                              onClick={() => setSelectedBkg(b)}
+                            >
+                              <div className="truncate font-semibold">{b.service?.name ?? '—'}</div>
+                              <div className="truncate opacity-75">{b.user?.name ?? '—'}</div>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
-      {/* Detail modal */}
-      <Modal
-        open={!!selectedBooking}
-        onClose={() => setSelectedBooking(null)}
-        title="Detalle del turno"
-        size="sm"
-      >
-        {selectedBooking && (
+      {/* ── Booking detail modal ──────────────────────────────────── */}
+      <Modal open={!!selectedBkg} onClose={() => setSelectedBkg(null)} title="Detalle del turno" size="sm">
+        {selectedBkg && (
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <div>
-                <h3 className="font-semibold text-content">{selectedBooking.service?.name ?? '—'}</h3>
-                <p className="text-sm text-content-3">{selectedBooking.business?.name ?? '—'}</p>
+                <h3 className="font-semibold text-content">{selectedBkg.service?.name ?? '—'}</h3>
+                <p className="text-sm text-content-3">{selectedBkg.business?.name ?? '—'}</p>
               </div>
-              <StatusBadge
-                label={selectedBooking.status}
-                variant={bookingStatusVariant(selectedBooking.status)}
-              />
+              <StatusBadge label={selectedBkg.status} variant={bookingStatusVariant(selectedBkg.status)} />
             </div>
             <dl className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <dt className="text-content-3">Cliente</dt>
-                <dd className="font-medium text-content">{selectedBooking.user?.name ?? '—'}</dd>
+                <dd className="font-medium text-content">{selectedBkg.user?.name ?? '—'}</dd>
               </div>
-              {selectedBooking.employee && (
+              {selectedBkg.employee && (
                 <div className="flex justify-between">
                   <dt className="text-content-3">Empleado</dt>
-                  <dd className="font-medium text-content">{selectedBooking.employee.name}</dd>
+                  <dd className="font-medium text-content">{selectedBkg.employee.name}</dd>
                 </div>
               )}
               <div className="flex justify-between">
                 <dt className="text-content-3">Inicio</dt>
                 <dd className="font-medium text-content">
-                  {new Date(selectedBooking.date).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
+                  {new Date(selectedBkg.date).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
                 </dd>
               </div>
               <div className="flex justify-between">
                 <dt className="text-content-3">Fin</dt>
                 <dd className="font-medium text-content">
-                  {new Date(selectedBooking.endTime).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
+                  {new Date(selectedBkg.endTime).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
                 </dd>
               </div>
-              {selectedBooking.service && (
+              {selectedBkg.service && (
                 <div className="flex justify-between">
                   <dt className="text-content-3">Duración</dt>
-                  <dd className="font-medium text-content">{selectedBooking.service.durationMin} min</dd>
+                  <dd className="font-medium text-content">{selectedBkg.service.durationMin} min</dd>
                 </div>
               )}
               <div className="flex justify-between">
                 <dt className="text-content-3">Precio</dt>
-                <dd className="font-bold text-content">${selectedBooking.finalPrice?.toLocaleString('es-AR') ?? '—'}</dd>
+                <dd className="font-bold text-content">${selectedBkg.finalPrice?.toLocaleString('es-AR') ?? '—'}</dd>
               </div>
             </dl>
           </div>
         )}
+      </Modal>
+
+      {/* ── New booking modal ─────────────────────────────────────── */}
+      <Modal open={showNewBkg} onClose={() => setShowNewBkg(false)} title="Nuevo turno">
+        <BookingForm
+          role="ADMIN"
+          businessId={businessId || undefined}
+          onSubmit={async data => {
+            try {
+              await createBooking(data);
+              toast('Turno creado', 'success');
+              setShowNewBkg(false);
+              fetchBookings();
+            } catch (err: any) {
+              toast(err.message || 'Error al crear el turno', 'error');
+              throw err;
+            }
+          }}
+        />
       </Modal>
     </div>
   );

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -76,24 +76,24 @@ const Dashboard: React.FC = () => {
     <div className="space-y-6">
       <div>
         <h2 className="text-xl font-bold text-content">¡Bienvenido, {user?.name}!</h2>
-        <p className="text-sm text-content-3 mt-0.5">Aquí puedes ver y gestionar todas tus reservas</p>
+        <p className="text-sm text-content-3 mt-0.5">Aquí podés ver y gestionar todas tus reservas</p>
       </div>
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard label="Total"      value={stats.total}     icon={<TurnosIcon />}   accent="primary" />
-        <StatCard label="Pendientes" value={stats.pending}   icon={<PendingIcon />}  accent="warning" />
+        <StatCard label="Total"       value={stats.total}     icon={<TurnosIcon />}   accent="primary" />
+        <StatCard label="Pendientes"  value={stats.pending}   icon={<PendingIcon />}  accent="warning" />
         <StatCard label="Confirmadas" value={stats.confirmed} icon={<ConfirmedIcon />} accent="success" />
-        <StatCard label="Canceladas" value={stats.cancelled} icon={<CancelledIcon />} accent="danger" />
+        <StatCard label="Canceladas"  value={stats.cancelled} icon={<CancelledIcon />} accent="danger" />
       </div>
 
       <div className="bg-surface rounded-xl shadow-card border border-border p-5">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-base font-semibold text-content">Mis Reservas</h3>
+          <h3 className="text-base font-semibold text-content">Historial de reservas</h3>
           <Link
             to="/bookings"
-            className="text-sm font-medium text-primary hover:text-primary-hover transition-colors"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-primary text-content-inverse rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
           >
-            Nueva reserva →
+            + Reservar turno
           </Link>
         </div>
 
@@ -117,8 +117,8 @@ const Dashboard: React.FC = () => {
             <svg className="mx-auto w-12 h-12 text-content-3 mb-3" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
               <rect x="3" y="4" width="18" height="18" rx="2" /><path strokeLinecap="round" d="M16 2v4M8 2v4M3 10h18" />
             </svg>
-            <p className="text-content-2 font-medium">No tienes reservas</p>
-            <p className="text-sm text-content-3 mt-1">Crea tu primera reserva para comenzar</p>
+            <p className="text-content-2 font-medium">No tenés reservas</p>
+            <p className="text-sm text-content-3 mt-1">Creá tu primera reserva para comenzar</p>
             <Link
               to="/bookings"
               className="inline-flex mt-4 px-4 py-2 bg-primary text-content-inverse rounded-lg text-sm font-medium hover:bg-primary-hover transition-colors"
@@ -127,25 +127,39 @@ const Dashboard: React.FC = () => {
             </Link>
           </div>
         ) : (
-          <div className="divide-y divide-border">
-            {bookings.map(b => (
-              <div key={b.id} className="py-4 flex items-start justify-between gap-4">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap mb-1">
-                    <span className="font-semibold text-content text-sm">{b.service.name}</span>
-                    <StatusBadge label={b.status} variant={bookingStatusVariant(b.status)} />
-                  </div>
-                  <p className="text-xs text-content-3">{b.business.name}</p>
-                  <p className="text-xs text-content-3 mt-0.5">
-                    {new Date(b.date).toLocaleDateString('es-AR', { weekday: 'short', day: 'numeric', month: 'short' })}
-                    {' · '}{b.startTime} – {b.endTime} ({b.service.durationMin} min)
-                  </p>
-                </div>
-                <div className="text-base font-bold text-content shrink-0">
-                  ${b.finalPrice.toLocaleString('es-AR')}
-                </div>
-              </div>
-            ))}
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="pb-3 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Servicio</th>
+                  <th className="pb-3 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Fecha y hora</th>
+                  <th className="pb-3 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Estado</th>
+                  <th className="pb-3 text-right text-xs font-medium text-content-3 uppercase tracking-wider">Precio</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {bookings.map(b => (
+                  <tr key={b.id} className="hover:bg-surface-2 transition-colors">
+                    <td className="py-3.5 pr-4">
+                      <p className="font-medium text-content">{b.service.name}</p>
+                      <p className="text-xs text-content-3 mt-0.5">{b.business.name}</p>
+                    </td>
+                    <td className="py-3.5 pr-4 text-content-2">
+                      <p>
+                        {new Date(b.date).toLocaleDateString('es-AR', { weekday: 'short', day: 'numeric', month: 'short' })}
+                      </p>
+                      <p className="text-xs text-content-3 mt-0.5">{b.startTime} – {b.endTime}</p>
+                    </td>
+                    <td className="py-3.5 pr-4">
+                      <StatusBadge label={b.status} variant={bookingStatusVariant(b.status)} />
+                    </td>
+                    <td className="py-3.5 text-right font-semibold text-content">
+                      ${b.finalPrice.toLocaleString('es-AR')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/client/src/pages/employeeDashboard.tsx
+++ b/client/src/pages/employeeDashboard.tsx
@@ -1,15 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useAuth } from '../context/AuthContext';
-import axios from 'axios';
+import { apiClient } from '../services/apiClient';
 import StatCard from '../components/ui/StatCard';
 import StatusBadge, { bookingStatusVariant } from '../components/ui/StatusBadge';
+import Avatar from '../components/ui/Avatar';
 import Modal from '../components/ui/Modal';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import Select from '../components/ui/Select';
 import { useToast } from '../components/ui/Toast';
-
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 interface Booking {
   id: string;
@@ -19,7 +18,7 @@ interface Booking {
   status: string;
   finalPrice: number;
   service: { name: string; durationMin: number };
-  user: { name: string; email: string };
+  user: { name: string; email: string } | null;
 }
 interface Service { id: string; name: string; durationMin: number; price: number; businessId: string }
 interface UserSearchResult { id: string; name: string; email: string; phone: string | null }
@@ -50,6 +49,16 @@ const PlusIcon = () => (
   </svg>
 );
 
+type StatusFilter = 'ALL' | 'PENDING' | 'CONFIRMED' | 'COMPLETED' | 'CANCELLED';
+
+const STATUS_TABS: { key: StatusFilter; label: string }[] = [
+  { key: 'ALL',       label: 'Todos' },
+  { key: 'PENDING',   label: 'Pendiente' },
+  { key: 'CONFIRMED', label: 'Confirmado' },
+  { key: 'COMPLETED', label: 'Completado' },
+  { key: 'CANCELLED', label: 'Cancelado' },
+];
+
 const EmployeeDashboard: React.FC = () => {
   const { user, token } = useAuth();
   const { toast } = useToast();
@@ -57,6 +66,7 @@ const EmployeeDashboard: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [updatingStatus, setUpdatingStatus] = useState<string | null>(null);
   const [stats, setStats] = useState({ today: 0, pending: 0, confirmed: 0, completed: 0 });
+  const [activeTab, setActiveTab] = useState<StatusFilter>('ALL');
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [services, setServices] = useState<Service[]>([]);
@@ -73,7 +83,7 @@ const EmployeeDashboard: React.FC = () => {
   const fetchBookings = async () => {
     try {
       setLoading(true);
-      const res = await axios.get(`${API_BASE_URL}/bookings/my-assignments`, { headers: { Authorization: `Bearer ${token}` } });
+      const res = await apiClient.get('/bookings/my-assignments');
       const transformed = res.data.map((b: any) => ({
         ...b,
         date:      new Date(b.date).toISOString().split('T')[0],
@@ -100,8 +110,11 @@ const EmployeeDashboard: React.FC = () => {
   const updateStatus = async (id: string, status: string) => {
     setUpdatingStatus(id);
     try {
-      await axios.patch(`${API_BASE_URL}/bookings/${id}/status`, { status }, { headers: { Authorization: `Bearer ${token}` } });
+      await apiClient.patch(`/bookings/${id}/status`, { status });
       setBookings(prev => prev.map(b => b.id === id ? { ...b, status } : b));
+      if (status === 'COMPLETED') {
+        setStats(prev => ({ ...prev, completed: prev.completed + 1 }));
+      }
       toast('Estado actualizado', 'success');
     } catch {
       toast('Error al actualizar el estado', 'error');
@@ -112,7 +125,7 @@ const EmployeeDashboard: React.FC = () => {
 
   const loadServices = async () => {
     try {
-      const res = await axios.get(`${API_BASE_URL}/services/my-business`, { headers: { Authorization: `Bearer ${token}` } });
+      const res = await apiClient.get('/services/my-business');
       setServices(res.data);
     } catch { /* empty */ }
   };
@@ -121,7 +134,7 @@ const EmployeeDashboard: React.FC = () => {
     if (q.trim().length < 3) { setSearchResults([]); return; }
     setSearchLoading(true);
     try {
-      const res = await axios.get(`${API_BASE_URL}/users/search`, { params: { email: q.trim() }, headers: { Authorization: `Bearer ${token}` } });
+      const res = await apiClient.get('/users/search', { params: { email: q.trim() } });
       setSearchResults(res.data);
     } catch { setSearchResults([]); }
     finally { setSearchLoading(false); }
@@ -134,10 +147,10 @@ const EmployeeDashboard: React.FC = () => {
     const [h, mi] = formData.startTime.split(':').map(Number);
     const start = new Date(y, mo - 1, d, h, mi);
     const end   = new Date(start.getTime() + svc.durationMin * 60000);
-    axios.get(`${API_BASE_URL}/bookings/available-employees?businessId=${svc.businessId}&date=${start.toISOString()}&endTime=${end.toISOString()}`, {
-      headers: { Authorization: `Bearer ${token}` }
-    }).then(r => setAvailableEmps(r.data)).catch(() => setAvailableEmps([]));
-  }, [formData.serviceId, formData.date, formData.startTime, services, token]);
+    apiClient.get(`/bookings/available-employees?businessId=${svc.businessId}&date=${start.toISOString()}&endTime=${end.toISOString()}`)
+      .then(r => setAvailableEmps(r.data))
+      .catch(() => setAvailableEmps([]));
+  }, [formData.serviceId, formData.date, formData.startTime, services]);
 
   const openModal = () => { setShowCreateModal(true); loadServices(); };
   const closeModal = () => {
@@ -162,7 +175,7 @@ const EmployeeDashboard: React.FC = () => {
     setCreating(true);
     try {
       const dt = new Date(`${formData.date}T${formData.startTime}:00`);
-      await axios.post(`${API_BASE_URL}/bookings`, {
+      await apiClient.post('/bookings', {
         ...(selectedClient && { userId: selectedClient.id }),
         serviceId: formData.serviceId,
         businessId: selectedService.businessId,
@@ -170,7 +183,7 @@ const EmployeeDashboard: React.FC = () => {
         finalPrice: selectedService.price,
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         ...(selectedEmpId && { employeeId: selectedEmpId }),
-      }, { headers: { Authorization: `Bearer ${token}` } });
+      });
       toast('Turno creado exitosamente', 'success');
       await fetchBookings();
       closeModal();
@@ -181,108 +194,185 @@ const EmployeeDashboard: React.FC = () => {
     }
   };
 
-  const sortedBookings = [...bookings].sort((a, b) => {
-    const dc = new Date(a.date).getTime() - new Date(b.date).getTime();
-    return dc !== 0 ? dc : a.startTime.localeCompare(b.startTime);
-  });
-  const isToday = (d: string) => d.startsWith(new Date().toISOString().split('T')[0]);
+  const todayStr = new Date().toISOString().split('T')[0];
+  const todayBookings = bookings
+    .filter(b => b.date.startsWith(todayStr))
+    .sort((a, b) => a.startTime.localeCompare(b.startTime));
+
+  const filteredBookings = bookings
+    .filter(b => activeTab === 'ALL' || b.status === activeTab)
+    .sort((a, b) => {
+      const dc = a.date.localeCompare(b.date);
+      return dc !== 0 ? dc : a.startTime.localeCompare(b.startTime);
+    });
 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div>
-          <h2 className="text-xl font-bold text-content">Panel de empleado</h2>
-          <p className="text-sm text-content-3 mt-0.5">Gestiona tus turnos asignados</p>
+          <h2 className="text-xl font-bold text-content">Mis Turnos</h2>
+          <p className="text-sm text-content-3 mt-0.5">Gestioná tus turnos asignados</p>
         </div>
         <Button leftIcon={<PlusIcon />} onClick={openModal}>Nueva reserva</Button>
       </div>
 
+      {/* Stats */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard label="Hoy"        value={stats.today}     icon={<TodayIcon />}    accent="primary" />
-        <StatCard label="Pendientes" value={stats.pending}   icon={<PendingIcon />}  accent="warning" />
+        <StatCard label="Turnos hoy"  value={stats.today}     icon={<TodayIcon />}    accent="primary" />
+        <StatCard label="Pendientes"  value={stats.pending}   icon={<PendingIcon />}  accent="warning" />
         <StatCard label="Confirmados" value={stats.confirmed} icon={<ConfirmedIcon />} accent="success" />
         <StatCard label="Completados" value={stats.completed} icon={<CompletedIcon />} accent="info" />
       </div>
 
-      <div className="bg-surface rounded-xl shadow-card border border-border p-5">
-        <h3 className="text-base font-semibold text-content mb-4">Turnos asignados</h3>
-        {loading ? (
-          <div className="flex items-center justify-center py-10 text-content-3 text-sm gap-2">
-            <svg className="animate-spin-slow w-5 h-5" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-            </svg>
-            Cargando…
-          </div>
-        ) : sortedBookings.length === 0 ? (
-          <div className="text-center py-10 text-content-3 text-sm">No hay turnos asignados en este momento</div>
-        ) : (
-          <div className="space-y-3">
-            {sortedBookings.map(b => (
-              <div
-                key={b.id}
-                className={`rounded-xl border p-4 ${isToday(b.date) ? 'border-primary/30 bg-primary-light' : 'border-border'}`}
-              >
-                <div className="flex items-start justify-between gap-4 flex-wrap">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap mb-1">
-                      {isToday(b.date) && (
-                        <span className="text-xs font-bold bg-primary text-content-inverse px-2 py-0.5 rounded-full">HOY</span>
-                      )}
-                      <span className="font-semibold text-content text-sm">{b.service.name}</span>
-                      <StatusBadge label={b.status} variant={bookingStatusVariant(b.status)} />
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-content-3 text-sm gap-2">
+          <svg className="animate-spin-slow w-5 h-5" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+          </svg>
+          Cargando…
+        </div>
+      ) : (
+        <>
+          {/* Today's bookings */}
+          {todayBookings.length > 0 && (
+            <div className="bg-surface rounded-xl shadow-card border border-border p-5">
+              <h3 className="text-sm font-semibold text-content-3 uppercase tracking-wider mb-4">
+                — Turnos de hoy ({todayBookings.length})
+              </h3>
+              <div className="space-y-3">
+                {todayBookings.map(b => (
+                  <div key={b.id} className="flex items-center gap-4 p-3 rounded-xl border border-primary/20 bg-primary-light">
+                    <Avatar name={b.user?.name || 'Walk-in'} size="md" className="shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="font-semibold text-sm text-content">{b.user?.name || 'Walk-in'}</p>
+                      <p className="text-xs text-content-3">
+                        {b.service.name} · {b.startTime} – {b.endTime}
+                      </p>
                     </div>
-                    <p className="text-xs text-content-2 font-medium">{b.user?.name || 'Walk-in'}</p>
-                    <p className="text-xs text-content-3 mt-0.5">
-                      {new Date(b.date).toLocaleDateString('es-AR', { weekday: 'short', day: 'numeric', month: 'short' })}
-                      {' · '}{b.startTime} – {b.endTime} ({b.service.durationMin} min)
-                    </p>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <span className="text-sm font-bold text-content">${b.finalPrice.toLocaleString('es-AR')}</span>
+                      <StatusBadge label={b.status} variant={bookingStatusVariant(b.status)} />
+                      {b.status !== 'COMPLETED' && b.status !== 'CANCELLED' && (
+                        <Button
+                          size="sm"
+                          loading={updatingStatus === b.id}
+                          disabled={updatingStatus !== null}
+                          onClick={() => updateStatus(b.id, 'COMPLETED')}
+                        >
+                          Completar
+                        </Button>
+                      )}
+                    </div>
                   </div>
-                  <div className="text-base font-bold text-content shrink-0">
-                    ${b.finalPrice.toLocaleString('es-AR')}
-                  </div>
-                </div>
-
-                {b.status !== 'COMPLETED' && b.status !== 'CANCELLED' && (
-                  <div className="flex gap-2 mt-3 pt-3 border-t border-border">
-                    <Button
-                      size="sm" variant="secondary"
-                      disabled={updatingStatus === b.id || b.status === 'CONFIRMED'}
-                      loading={updatingStatus === b.id}
-                      onClick={() => updateStatus(b.id, 'CONFIRMED')}
-                      className="flex-1"
-                    >
-                      {b.status === 'CONFIRMED' ? '✓ Confirmado' : 'Confirmar'}
-                    </Button>
-                    <Button
-                      size="sm"
-                      disabled={updatingStatus === b.id}
-                      loading={updatingStatus === b.id}
-                      onClick={() => updateStatus(b.id, 'COMPLETED')}
-                      className="flex-1"
-                    >
-                      Completar
-                    </Button>
-                    <Button
-                      size="sm" variant="danger"
-                      disabled={updatingStatus === b.id}
-                      onClick={() => updateStatus(b.id, 'CANCELLED')}
-                      className="flex-1"
-                    >
-                      Cancelar
-                    </Button>
-                  </div>
-                )}
+                ))}
               </div>
-            ))}
+            </div>
+          )}
+
+          {/* All bookings with tabs */}
+          <div className="bg-surface rounded-xl shadow-card border border-border p-5">
+            <h3 className="text-base font-semibold text-content mb-4">Todos los turnos</h3>
+
+            {/* Tab filter */}
+            <div className="flex items-center gap-1 mb-5 flex-wrap">
+              {STATUS_TABS.map(tab => (
+                <button
+                  key={tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                    activeTab === tab.key
+                      ? 'bg-primary text-content-inverse'
+                      : 'text-content-2 hover:bg-surface-2'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            {filteredBookings.length === 0 ? (
+              <div className="text-center py-8 text-content-3 text-sm">
+                No hay turnos {activeTab !== 'ALL' ? 'con ese estado' : 'asignados'}
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-border">
+                      <th className="pb-3 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Servicio / Cliente</th>
+                      <th className="pb-3 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Fecha y hora</th>
+                      <th className="pb-3 text-left text-xs font-medium text-content-3 uppercase tracking-wider">Estado</th>
+                      <th className="pb-3 text-right text-xs font-medium text-content-3 uppercase tracking-wider">Precio</th>
+                      <th className="pb-3 text-right text-xs font-medium text-content-3 uppercase tracking-wider">Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {filteredBookings.map(b => {
+                      const isToday = b.date.startsWith(todayStr);
+                      return (
+                        <tr key={b.id} className="hover:bg-surface-2 transition-colors">
+                          <td className="py-3.5 pr-4">
+                            <p className="font-medium text-content">{b.service.name}</p>
+                            <div className="flex items-center gap-1.5 mt-0.5">
+                              <span className="text-xs text-content-3">{b.user?.name || 'Walk-in'}</span>
+                            </div>
+                          </td>
+                          <td className="py-3.5 pr-4">
+                            <div className="flex items-center gap-1.5">
+                              {isToday && (
+                                <span className="text-xs font-bold bg-primary text-content-inverse px-1.5 py-0.5 rounded">HOY</span>
+                              )}
+                              <span className="text-content-2">
+                                {new Date(b.date).toLocaleDateString('es-AR', { day: 'numeric', month: 'short' })}
+                              </span>
+                            </div>
+                            <p className="text-xs text-content-3 mt-0.5">{b.startTime} – {b.endTime}</p>
+                          </td>
+                          <td className="py-3.5 pr-4">
+                            <StatusBadge label={b.status} variant={bookingStatusVariant(b.status)} />
+                          </td>
+                          <td className="py-3.5 pr-4 text-right font-semibold text-content">
+                            ${b.finalPrice.toLocaleString('es-AR')}
+                          </td>
+                          <td className="py-3.5 text-right">
+                            {b.status !== 'COMPLETED' && b.status !== 'CANCELLED' && (
+                              <div className="flex items-center justify-end gap-1.5">
+                                {b.status === 'PENDING' && (
+                                  <Button
+                                    size="sm" variant="secondary"
+                                    loading={updatingStatus === b.id}
+                                    disabled={updatingStatus !== null}
+                                    onClick={() => updateStatus(b.id, 'CONFIRMED')}
+                                  >
+                                    Confirmar
+                                  </Button>
+                                )}
+                                <Button
+                                  size="sm"
+                                  loading={updatingStatus === b.id}
+                                  disabled={updatingStatus !== null}
+                                  onClick={() => updateStatus(b.id, 'COMPLETED')}
+                                >
+                                  Completar
+                                </Button>
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </>
+      )}
 
       {/* Create booking modal */}
       <Modal open={showCreateModal} onClose={closeModal} title="Nueva reserva" size="md">
         <form onSubmit={handleCreate} className="space-y-5">
-          {/* Client search */}
           <div>
             <div className="flex items-center justify-between mb-1.5">
               <label className="text-sm font-medium text-content-2">Cliente</label>

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -6,6 +6,12 @@ import { redirectByRole } from '../context/AuthContext';
 import Input from '../components/ui/Input';
 import Button from '../components/ui/Button';
 
+const TEST_CREDENTIALS = [
+  { email: 'admin1@test.com',    role: 'Admin' },
+  { email: 'employee1@test.com', role: 'Empleado' },
+  { email: 'client1@test.com',   role: 'Cliente' },
+];
+
 const Login: React.FC = () => {
   const { login } = useAuth();
   const navigate = useNavigate();
@@ -24,7 +30,7 @@ const Login: React.FC = () => {
       navigate(redirectByRole(data.user.role));
     } catch (err: unknown) {
       if (!navigator.onLine) {
-        setError('Sin conexión a internet. Verifica tu red.');
+        setError('Sin conexión a internet. Verificá tu red.');
       } else if (err instanceof Error) {
         setError(err.message);
       } else {
@@ -35,25 +41,82 @@ const Login: React.FC = () => {
     }
   };
 
-  return (
-    <div className="min-h-dvh flex flex-col bg-surface-2">
-      {/* Simple top bar */}
-      <header className="flex items-center justify-between px-6 h-16 border-b border-border bg-surface">
-        <Link to="/home" className="font-bold text-base text-content tracking-tight hover:text-primary transition-colors">
-          ShiftManager
-        </Link>
-        <Link to="/register" className="text-sm text-content-2 hover:text-content transition-colors">
-          ¿No tenés cuenta? <span className="font-semibold text-primary">Registrate</span>
-        </Link>
-      </header>
+  const fillCredential = (cred: typeof TEST_CREDENTIALS[number]) => {
+    setEmail(cred.email);
+    setPassword('password123');
+    setError(null);
+  };
 
-      {/* Form */}
-      <div className="flex-1 flex items-center justify-center px-4 py-12">
+  return (
+    <div className="min-h-dvh flex">
+      {/* Left dark panel */}
+      <div className="hidden lg:flex w-[42%] xl:w-2/5 bg-sidebar flex-col p-10 shrink-0">
+        {/* Logo */}
+        <Link to="/home" className="flex items-center gap-3 mb-12">
+          <div className="w-10 h-10 rounded-xl bg-primary flex items-center justify-center shrink-0">
+            <svg width="22" height="22" fill="none" stroke="white" strokeWidth="2" viewBox="0 0 24 24">
+              <rect x="3" y="4" width="18" height="18" rx="2" />
+              <path strokeLinecap="round" d="M16 2v4M8 2v4M3 10h18M8 14h.01M12 14h.01M16 14h.01M8 18h.01M12 18h.01" />
+            </svg>
+          </div>
+          <span className="text-white font-bold text-lg tracking-tight">ShiftManager</span>
+        </Link>
+
+        {/* Description */}
+        <div className="flex-1">
+          <h1 className="text-white text-2xl font-bold leading-snug mb-3">
+            Gestión de turnos para negocios.
+          </h1>
+          <p className="text-sidebar-text text-sm leading-relaxed">
+            Reservas, empleados y métricas en un solo lugar.
+          </p>
+        </div>
+
+        {/* Test credentials */}
+        <div>
+          <p className="text-xs font-semibold text-sidebar-text uppercase tracking-wider mb-3">
+            Acceso rápido (demo)
+          </p>
+          <div className="bg-white/5 rounded-xl overflow-hidden divide-y divide-white/5">
+            {TEST_CREDENTIALS.map(cred => (
+              <button
+                key={cred.email}
+                type="button"
+                onClick={() => fillCredential(cred)}
+                className="w-full flex items-center justify-between px-4 py-3 hover:bg-white/10 transition-colors text-left"
+              >
+                <div className="flex items-center gap-2.5">
+                  <span className="w-2 h-2 rounded-full bg-success shrink-0" />
+                  <span className="text-sidebar-text-active text-sm">{cred.email}</span>
+                </div>
+                <span className="text-xs text-sidebar-text">{cred.role}</span>
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-sidebar-text mt-2.5 opacity-60">
+            Contraseña: password123
+          </p>
+        </div>
+      </div>
+
+      {/* Right white panel */}
+      <div className="flex-1 flex items-center justify-center px-6 py-12 bg-surface-2">
         <div className="w-full max-w-sm">
+          {/* Mobile logo */}
+          <Link to="/home" className="flex items-center justify-center gap-2 mb-8 lg:hidden">
+            <div className="w-8 h-8 rounded-lg bg-primary flex items-center justify-center">
+              <svg width="16" height="16" fill="none" stroke="white" strokeWidth="2" viewBox="0 0 24 24">
+                <rect x="3" y="4" width="18" height="18" rx="2" />
+                <path strokeLinecap="round" d="M16 2v4M8 2v4M3 10h18" />
+              </svg>
+            </div>
+            <span className="font-bold text-content">ShiftManager</span>
+          </Link>
+
           <div className="bg-surface rounded-2xl shadow-modal p-8 animate-fade-in">
-            <div className="mb-6 text-center">
-              <h1 className="text-2xl font-bold text-content">Bienvenido de nuevo</h1>
-              <p className="text-sm text-content-3 mt-1">Ingresá tus credenciales para continuar</p>
+            <div className="mb-6">
+              <h2 className="text-xl font-bold text-content">Bienvenido</h2>
+              <p className="text-sm text-content-3 mt-1">Ingresá con tus credenciales para continuar.</p>
             </div>
 
             <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -62,7 +125,7 @@ const Login: React.FC = () => {
                 type="email"
                 value={email}
                 onChange={e => setEmail(e.target.value)}
-                placeholder="nombre@email.com"
+                placeholder="tu@email.com"
                 required
                 autoComplete="email"
                 leftIcon={
@@ -92,7 +155,7 @@ const Login: React.FC = () => {
                 </div>
               )}
 
-              <Button type="submit" loading={loading} className="w-full mt-2" size="lg">
+              <Button type="submit" loading={loading} className="w-full mt-1" size="lg">
                 Ingresar
               </Button>
             </form>

--- a/client/src/pages/users.tsx
+++ b/client/src/pages/users.tsx
@@ -132,7 +132,7 @@ const Users: React.FC = () => {
     <div className="space-y-6">
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div>
-          <h2 className="text-xl font-bold text-content">Usuarios</h2>
+          <h2 className="text-xl font-bold text-content">Empleados</h2>
           <p className="text-sm text-content-3 mt-0.5">Gestioná los empleados de tu negocio</p>
         </div>
         {selectedBusiness && <Button leftIcon={<PlusIcon />} onClick={() => setShowCreate(true)}>Nuevo empleado</Button>}


### PR DESCRIPTION
## Summary

- **Login**: split-panel layout with test credential quick-fill panel
- **Sidebar**: role-based navigation — each role (ADMIN/EMPLOYEE/CLIENT) sees only its own routes
- **Admin dashboard**: KPI stat cards, CSS bar chart (turnos por mes), recent bookings panel — metrics now cover the full year
- **Client dashboard**: booking history converted to table layout with stat cards
- **Employee dashboard**: today's appointments section + filterable history table with status tabs
- **Calendar**: full redesign — left panel (mini-calendar + today's list + employee filter), main area with Semana/Día toggle; day view uses employee columns with color-coded booking chips; only shows employees from the admin's own business
- **Avatar**: colors derived from name hash for visual variety
- **StatCard**: added optional `subtitle` prop

## Test plan

- [ ] Login: click each credential chip → form auto-fills → login succeeds for Admin, Employee and Client
- [ ] Sidebar: verify each role sees only its own nav items with correct routes
- [ ] Admin dashboard: stat cards show values, bar chart renders, recent bookings list populates
- [ ] Client dashboard: booking table renders with correct columns and status badges
- [ ] Employee dashboard: today's section shows current-day bookings; tab filter works
- [ ] Calendar day view: employee columns appear, booking chips are color-coded and clickable
- [ ] Calendar week view: 7-day grid renders, clicking a day switches to day view
- [ ] Calendar employee filter: selecting an employee hides other employees' bookings
- [ ] Calendar: employees shown belong only to the admin's business
- [ ] "+ Nuevo turno" modal opens and creates a booking successfully