### PR TITLE
feat(ui): complete UI redesign v0.4.0 — 9 gaps implemented

### DIFF
--- a/.claude/CLAUDE_CODE_INSTRUCTIONS.md
+++ b/.claude/CLAUDE_CODE_INSTRUCTIONS.md
@@ -1,0 +1,748 @@
+# Claude Code — Instrucciones de implementación: Shift Management UI Gaps
+
+## Contexto
+
+Este documento describe los **gaps pendientes** entre el rediseño de referencia (archivos HTML en esta carpeta) y el estado actual del codebase en `https://github.com/NahuelArg/shift-management`.
+
+**Lo que ya está bien implementado** (no tocar):
+- Sidebar colapsable con roles (`Sidebar.tsx`)
+- TopBar, AppShell, MobileTabBar
+- Design tokens OKLCH en `tailwind.config.js`
+- DM Sans + DM Mono en `index.css`
+- Componentes UI: StatCard, StatusBadge, Avatar, Button, Input, Modal, Select, Toast
+- SidebarContext
+- Login split-panel (desktop)
+- Calendario semanal/diario con mini-cal y filtro de empleados
+- Calendario mobile: vista 3 días centrada en hoy (ya implementada)
+
+**Stack**: React 19 + TypeScript + Tailwind CSS + React Router v7 + Axios + NestJS backend
+
+---
+
+## Reglas generales
+
+- Usar clases Tailwind siempre que sea posible (no CSS inline)
+- Componentes UI reutilizables ya existen en `client/src/components/ui/` — usarlos, no duplicar
+- Mantener todos los endpoints y servicios existentes intactos
+- No cambiar AuthContext, lógica de auth, ni PrivateRoute
+- Cada página ya tiene sus llamadas a la API — solo cambiar presentación, no lógica
+- Referencia visual: abrir `Shift Admin Screens.html` y `Shift Management.html` del handoff
+
+---
+
+## Gap 1 — Calendario: detalles finos
+
+**Archivo:** `client/src/pages/calendar.tsx`
+
+### 1a. Línea "ahora" (current time indicator)
+
+Agregar un indicador rojo de la hora actual en la columna de hoy, que se actualice cada minuto.
+
+```tsx
+// Dentro del componente Calendar, agregar:
+const [nowMinutes, setNowMinutes] = useState(() => {
+  const n = new Date();
+  return n.getHours() * 60 + n.getMinutes();
+});
+
+useEffect(() => {
+  const interval = setInterval(() => {
+    const n = new Date();
+    setNowMinutes(n.getHours() * 60 + n.getMinutes());
+  }, 60_000);
+  return () => clearInterval(interval);
+}, []);
+```
+
+En la vista semana, dentro de la columna que corresponde a `isSameDay(day, new Date())`:
+```tsx
+{isSameDay(day, new Date()) && (
+  <div
+    className="absolute left-0 right-0 z-10 pointer-events-none flex items-center"
+    style={{ top: `${((nowMinutes - 8 * 60) / (HOURS.length * 60)) * 100}%` }}
+  >
+    <div className="w-2 h-2 rounded-full bg-danger shrink-0 -ml-1" />
+    <div className="flex-1 h-px bg-danger" />
+  </div>
+)}
+```
+
+Mismo patrón en la vista día, para cada columna de empleado.
+
+### 1b. Líneas de media hora (dashed)
+
+Actualmente solo hay líneas de hora completa. Agregar líneas punteadas a los :30:
+
+```tsx
+{HOURS.map(h => (
+  <React.Fragment key={h}>
+    {/* Hora completa — solid */}
+    <div
+      className="absolute w-full border-t border-border/40"
+      style={{ top: `${(h - 8) * CELL_H}px` }}
+    />
+    {/* Media hora — dashed */}
+    <div
+      className="absolute w-full border-t border-dashed border-border/20"
+      style={{ top: `${(h - 8) * CELL_H + CELL_H / 2}px` }}
+    />
+  </React.Fragment>
+))}
+```
+
+### 1c. DM Mono en etiquetas de hora
+
+Las etiquetas `08:00`, `09:00` etc. deben usar `font-mono`:
+```tsx
+<span className="text-xs text-content-3 mt-1 font-mono">{hLabel(h)}</span>
+```
+
+### 1d. Panel de detalle lateral (slide-in) en desktop
+
+Actualmente el detalle abre en un `Modal` centrado. En desktop (≥ md), debe ser un panel lateral deslizable (slide-in desde la derecha, dentro del área del calendario, no fixed). En mobile mantener el modal.
+
+```tsx
+// En el área principal, cambiar la estructura:
+<div className="flex-1 min-w-0 flex overflow-hidden relative">
+  {/* Grid del calendario */}
+  <div className={`flex flex-col bg-surface rounded-xl shadow-card border border-border overflow-hidden transition-all duration-200
+    ${selectedBkg && !isMobile ? 'flex-1' : 'flex-1'}`}>
+    {/* ...grid existente... */}
+  </div>
+
+  {/* Panel lateral de detalle — desktop only */}
+  {selectedBkg && (
+    <aside className="hidden md:flex w-72 shrink-0 ml-4 bg-surface rounded-xl shadow-card border border-border flex-col overflow-hidden animate-slide-in-right">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <span className="text-sm font-bold text-content">Detalle del turno</span>
+        <button onClick={() => setSelectedBkg(null)} className="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-surface-3 text-content-3 transition-colors">
+          ✕
+        </button>
+      </div>
+      {/* Contenido igual al modal actual */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {/* ...mismos campos del modal... */}
+        {/* Agregar acciones de estado */}
+        {selectedBkg.status !== 'CANCELLED' && selectedBkg.status !== 'COMPLETED' && (
+          <div className="flex flex-col gap-2 pt-2 border-t border-border">
+            {selectedBkg.status === 'PENDING' && (
+              <button className="w-full py-2 rounded-lg bg-success text-white text-sm font-semibold">
+                Confirmar turno
+              </button>
+            )}
+            <button className="w-full py-2 rounded-lg bg-primary text-white text-sm font-semibold">
+              Marcar completado
+            </button>
+            <button className="w-full py-2 rounded-lg border border-border text-danger text-sm font-semibold">
+              Cancelar turno
+            </button>
+          </div>
+        )}
+      </div>
+    </aside>
+  )}
+</div>
+```
+
+Agregar keyframe en `tailwind.config.js`:
+```js
+'slide-in-right': {
+  from: { transform: 'translateX(20px)', opacity: '0' },
+  to:   { transform: 'translateX(0)',    opacity: '1' },
+},
+// En animation:
+'slide-in-right': 'slide-in-right 0.2s ease-out',
+```
+
+El Modal existente solo mostrarlo en mobile (`md:hidden`):
+```tsx
+<Modal open={!!selectedBkg && isMobile} onClose={() => setSelectedBkg(null)} ...>
+```
+
+Donde `isMobile` se puede detectar con:
+```tsx
+const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+// O mejor con un hook useMediaQuery
+```
+
+---
+
+## Gap 2 — Employee Dashboard: mejoras visuales
+
+**Archivo:** `client/src/pages/employeeDashboard.tsx`
+
+### 2a. Sección "Turnos de hoy" destacada
+
+Los turnos del día actual deben tener un bloque visual diferenciado, encima del listado general.
+
+```tsx
+// Filtrar turnos de hoy
+const todayStr = new Date().toISOString().slice(0, 10);
+const todayBookings = sortedBookings.filter(b => b.date.startsWith(todayStr));
+const otherBookings = sortedBookings.filter(b => !b.date.startsWith(todayStr));
+
+// Renderizar sección de hoy (si hay turnos)
+{todayBookings.length > 0 && (
+  <div className="mb-6 p-4 rounded-xl bg-success/5 border border-success/20">
+    <div className="flex items-center justify-between mb-3">
+      <p className="text-xs font-bold text-success uppercase tracking-wider">
+        Turnos de hoy — {todayBookings.length}
+      </p>
+      {/* Barra de progreso */}
+      <span className="text-xs text-content-3">
+        {todayBookings.filter(b => b.status === 'COMPLETED').length} / {todayBookings.length} completados
+      </span>
+    </div>
+    {/* Barra de progreso */}
+    <div className="h-1.5 bg-surface-3 rounded-full mb-4 overflow-hidden">
+      <div
+        className="h-full bg-success rounded-full transition-all duration-500"
+        style={{ width: `${(todayBookings.filter(b => b.status === 'COMPLETED').length / todayBookings.length) * 100}%` }}
+      />
+    </div>
+    {/* Cards de turnos de hoy */}
+    <div className="space-y-2">
+      {todayBookings.map(booking => (
+        <div key={booking.id} className="flex items-center gap-3 p-3 bg-surface rounded-xl border border-border shadow-sm">
+          {/* Hora badge */}
+          <div className="bg-success-light rounded-lg px-2 py-2 text-center shrink-0 min-w-[48px]">
+            <p className="text-xs font-bold text-success font-mono leading-none">{booking.startTime}</p>
+            <p className="text-xs text-success opacity-70 mt-0.5">{booking.service.durationMin}m</p>
+          </div>
+          {/* Info */}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-content truncate">{booking.user?.name ?? 'Walk-in'}</p>
+            <p className="text-xs text-content-3">{booking.service.name}</p>
+          </div>
+          {/* Precio + acciones */}
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="text-sm font-bold text-content font-mono">${booking.finalPrice.toLocaleString()}</span>
+            <StatusBadge label={booking.status} variant={bookingStatusVariant(booking.status)} />
+            {booking.status !== 'COMPLETED' && booking.status !== 'CANCELLED' && (
+              <button
+                onClick={() => updateBookingStatus(booking.id, 'COMPLETED')}
+                className="px-2.5 py-1 rounded-lg bg-success text-white text-xs font-semibold"
+              >
+                ✓
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+)}
+```
+
+### 2b. Filtros por estado (chips)
+
+Agregar antes de la lista general:
+```tsx
+const [filterStatus, setFilterStatus] = useState<string>('all');
+
+const FILTER_OPTIONS = [
+  { id: 'all',       label: 'Todos' },
+  { id: 'PENDING',   label: 'Pendientes' },
+  { id: 'CONFIRMED', label: 'Confirmados' },
+  { id: 'COMPLETED', label: 'Completados' },
+];
+
+// UI:
+<div className="flex gap-2 flex-wrap mb-4">
+  {FILTER_OPTIONS.map(opt => (
+    <button
+      key={opt.id}
+      onClick={() => setFilterStatus(opt.id)}
+      className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors
+        ${filterStatus === opt.id
+          ? 'bg-primary text-content-inverse'
+          : 'bg-surface-3 text-content-2 hover:bg-surface-2'}`}
+    >
+      {opt.label}
+    </button>
+  ))}
+</div>
+
+// Filtrar la lista:
+const displayedBookings = (filterStatus === 'all' ? otherBookings : otherBookings.filter(b => b.status === filterStatus));
+```
+
+---
+
+## Gap 3 — Servicios: stats row + mejoras de tabla
+
+**Archivo:** `client/src/pages/services.tsx`
+
+### 3a. Stats row encima de la tabla
+
+```tsx
+// Calcular stats de los servicios cargados
+const avgPrice    = services.length ? Math.round(services.reduce((s, sv) => s + sv.price, 0) / services.length) : 0;
+const avgDuration = services.length ? Math.round(services.reduce((s, sv) => s + sv.durationMin, 0) / services.length) : 0;
+const bizCount    = new Set(services.map(sv => sv.businessId)).size;
+
+// Render — antes de los filtros:
+<div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+  <StatCard label="Total servicios" value={services.length}   icon={<ScissorsIcon />} accent="primary" />
+  <StatCard label="Precio promedio" value={`$${avgPrice.toLocaleString()}`} icon={<CoinIcon />} accent="success" />
+  <StatCard label="Duración prom."  value={`${avgDuration} min`}            icon={<ClockIcon />} accent="warning" />
+  <StatCard label="Negocios"        value={bizCount}          icon={<BuildingIcon />} accent="info" />
+</div>
+```
+
+### 3b. Acciones como íconos con hover coloreado
+
+Reemplazar los botones de texto "Editar" / "Eliminar" por íconos:
+
+```tsx
+// En cada fila de la tabla, columna de acciones:
+<div className="flex items-center gap-1">
+  <button
+    onClick={() => handleEdit(service)}
+    className="w-7 h-7 flex items-center justify-center rounded-md border border-border text-content-3
+               hover:border-primary hover:text-primary hover:bg-primary-light transition-colors"
+    title="Editar"
+  >
+    <PencilIcon size={13} />
+  </button>
+  <button
+    onClick={() => handleDelete(service.id)}
+    className="w-7 h-7 flex items-center justify-center rounded-md border border-border text-content-3
+               hover:border-danger hover:text-danger hover:bg-danger-light transition-colors"
+    title="Eliminar"
+  >
+    <TrashIcon size={13} />
+  </button>
+</div>
+```
+
+### 3c. Filtro por negocio en toolbar
+
+```tsx
+const [filterBusiness, setFilterBusiness] = useState('all');
+
+// En el toolbar (junto al search):
+<select
+  value={filterBusiness}
+  onChange={e => setFilterBusiness(e.target.value)}
+  className="px-3 py-1.5 rounded-lg border border-border bg-surface text-sm text-content focus:border-primary outline-none"
+>
+  <option value="all">Todos los negocios</option>
+  {businesses.map(b => (
+    <option key={b.id} value={b.id}>{b.name}</option>
+  ))}
+</select>
+
+// Filtrar:
+const filtered = services.filter(s =>
+  (filterBusiness === 'all' || s.businessId === filterBusiness) &&
+  // ...búsqueda por nombre si ya existe...
+);
+```
+
+---
+
+## Gap 4 — Horarios: vista semanal grid
+
+**Archivo:** `client/src/pages/schedules.tsx`
+
+### 4a. Agregar vista semanal visual encima de la tabla
+
+```tsx
+const DAYS_SHORT = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+
+// Render — antes de la tabla existente:
+<div className="bg-surface rounded-xl shadow-card border border-border overflow-hidden mb-6">
+  <div className="px-4 py-3 border-b border-border">
+    <p className="text-sm font-semibold text-content">Vista semanal</p>
+  </div>
+  <div className="grid grid-cols-7">
+    {[0,1,2,3,4,5,6].map((dayIdx, i) => {
+      const daySchedules = schedules.filter(s =>
+        s.businessId === selectedBusinessId && s.dayOfWeek === dayIdx
+      );
+      const isWeekend = dayIdx === 0 || dayIdx === 6;
+      return (
+        <div
+          key={dayIdx}
+          className={`p-3 min-h-[80px] border-r border-border last:border-r-0
+            ${daySchedules.length > 0 ? 'bg-bg' : 'bg-surface-2'}
+            ${isWeekend && daySchedules.length === 0 ? 'opacity-50' : ''}`}
+        >
+          <p className={`text-xs font-bold uppercase tracking-wider mb-2
+            ${daySchedules.length > 0 ? 'text-primary' : 'text-content-3'}`}>
+            {DAYS_SHORT[dayIdx]}
+          </p>
+          {daySchedules.length > 0 ? (
+            daySchedules.map(s => (
+              <button
+                key={s.id}
+                onClick={() => handleEdit(s)}
+                className="w-full text-left px-2 py-1.5 rounded-md mb-1
+                           bg-primary/10 border border-primary/30
+                           hover:bg-primary/15 transition-colors"
+              >
+                <p className="text-xs font-bold text-primary font-mono">
+                  {s.from}–{s.to}
+                </p>
+              </button>
+            ))
+          ) : (
+            <p className="text-xs text-content-3 italic">Cerrado</p>
+          )}
+        </div>
+      );
+    })}
+  </div>
+</div>
+```
+
+### 4b. Cálculo automático de duración en modal
+
+Agregar debajo de los inputs de hora en el formulario:
+
+```tsx
+{formData.from && formData.to && (() => {
+  const [h1, m1] = formData.from.split(':').map(Number);
+  const [h2, m2] = formData.to.split(':').map(Number);
+  const mins = (h2 * 60 + m2) - (h1 * 60 + m1);
+  if (mins <= 0) return (
+    <p className="text-xs text-danger bg-danger-light px-3 py-2 rounded-lg">
+      ⚠️ La hora de cierre debe ser posterior a la de apertura
+    </p>
+  );
+  return (
+    <p className="text-xs text-primary bg-primary-light px-3 py-2 rounded-lg font-medium">
+      ⏱ Duración: {Math.floor(mins / 60)}h {mins % 60}m
+    </p>
+  );
+})()}
+```
+
+---
+
+## Gap 5 — Negocio: layout maestro-detalle
+
+**Archivo:** `client/src/pages/business.tsx`
+
+### Layout actual → master-detail
+
+Cambiar el layout de la página a dos paneles:
+
+```tsx
+return (
+  <div className="flex gap-4 h-full min-h-0">
+
+    {/* Panel izquierdo — lista de negocios */}
+    <aside className="w-64 shrink-0 bg-surface rounded-xl shadow-card border border-border flex flex-col overflow-hidden">
+      <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+        <p className="text-xs font-bold text-content-3 uppercase tracking-wider">
+          Mis negocios ({businesses.length})
+        </p>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2">
+        {businesses.map(business => (
+          <button
+            key={business.id}
+            onClick={() => setSelectedBusiness(business)}
+            className={`w-full flex items-center gap-3 p-3 rounded-xl mb-1 text-left transition-all
+              ${selectedBusiness?.id === business.id
+                ? 'bg-info/10 border-l-2 border-info'
+                : 'hover:bg-surface-2 border-l-2 border-transparent'}`}
+          >
+            <div className="w-9 h-9 rounded-xl bg-info-light flex items-center justify-center shrink-0">
+              <BuildingIcon className="text-info" size={16} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-content truncate">{business.name}</p>
+              <p className="text-xs text-content-3">
+                {/* Mostrar cant. servicios si está disponible */}
+              </p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </aside>
+
+    {/* Panel derecho — detalle */}
+    {selectedBusiness ? (
+      <div className="flex-1 min-w-0 overflow-y-auto space-y-4 animate-fade-in">
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-4">
+            <div className="w-14 h-14 rounded-2xl bg-info-light border border-info/20 flex items-center justify-center">
+              <BuildingIcon size={24} className="text-info" />
+            </div>
+            <div>
+              <h2 className="text-xl font-bold text-content">{selectedBusiness.name}</h2>
+              <p className="text-sm text-content-3">
+                Creado: {new Date(selectedBusiness.createdAt).toLocaleDateString('es-AR', { day:'numeric', month:'long', year:'numeric' })}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => handleEdit(selectedBusiness)}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg border border-border text-sm font-medium text-content-2 hover:border-info hover:text-info transition-colors"
+          >
+            <PencilIcon size={14} /> Editar
+          </button>
+        </div>
+
+        {/* Info cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {[
+            { label: 'Dirección', value: selectedBusiness.address, emoji: '📍' },
+            { label: 'Teléfono',  value: selectedBusiness.phone,   emoji: '📞' },
+            { label: 'Email',     value: selectedBusiness.email,   emoji: '✉️' },
+          ].map(info => (
+            <div key={info.label} className="flex items-center gap-3 p-4 bg-surface rounded-xl shadow-card border border-border">
+              <div className="w-9 h-9 rounded-lg bg-surface-3 flex items-center justify-center text-base shrink-0">
+                {info.emoji}
+              </div>
+              <div>
+                <p className="text-xs text-content-3 uppercase tracking-wider">{info.label}</p>
+                <p className="text-sm font-medium text-content">{info.value || '—'}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Servicios del negocio */}
+        {/* Reutilizar la lógica existente de servicios, filtrada por businessId */}
+      </div>
+    ) : (
+      <div className="flex-1 flex items-center justify-center text-content-3 text-sm">
+        Seleccioná un negocio para ver el detalle
+      </div>
+    )}
+  </div>
+);
+```
+
+Agregar state: `const [selectedBusiness, setSelectedBusiness] = useState(businesses[0] ?? null);`
+Actualizar `selectedBusiness` cuando cambie `businesses`.
+
+---
+
+## Gap 6 — Usuarios: stats row + panel de detalle
+
+**Archivo:** `client/src/pages/users.tsx`
+
+### 6a. Stats row
+
+```tsx
+const adminCount    = users.filter(u => u.role === 'ADMIN').length;
+const employeeCount = users.filter(u => u.role === 'EMPLOYEE').length;
+const clientCount   = users.filter(u => u.role === 'CLIENT').length;
+
+// Antes de los filtros:
+<div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+  <StatCard label="Total usuarios" value={users.length}   icon={<UsersIcon />} accent="primary" />
+  <StatCard label="Admins"         value={adminCount}     icon={<ShieldIcon />} accent="info" />
+  <StatCard label="Empleados"      value={employeeCount}  icon={<UsersIcon />} accent="success" />
+  <StatCard label="Clientes"       value={clientCount}    icon={<UserIcon />} accent="warning" />
+</div>
+```
+
+### 6b. Filtros por rol (chips)
+
+```tsx
+const [filterRole, setFilterRole] = useState<string>('all');
+
+const ROLE_FILTERS = [
+  { id: 'all',      label: 'Todos' },
+  { id: 'ADMIN',    label: 'Admins' },
+  { id: 'EMPLOYEE', label: 'Empleados' },
+  { id: 'CLIENT',   label: 'Clientes' },
+];
+
+// UI (junto al search):
+<div className="flex gap-2 flex-wrap">
+  {ROLE_FILTERS.map(f => (
+    <button
+      key={f.id}
+      onClick={() => setFilterRole(f.id)}
+      className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors
+        ${filterRole === f.id
+          ? 'bg-primary text-content-inverse'
+          : 'bg-surface-3 text-content-2 hover:bg-surface-2'}`}
+    >
+      {f.label}
+    </button>
+  ))}
+</div>
+```
+
+### 6c. Panel lateral de detalle (click en fila)
+
+```tsx
+const [selectedUser, setSelectedUser] = useState<User | null>(null);
+
+// Cambiar layout de la página:
+<div className="flex gap-4 h-full min-h-0">
+  <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
+    {/* stats + filtros + tabla existente */}
+    {/* En cada fila de la tabla: onClick={() => setSelectedUser(user)} */}
+    {/* Fila activa: className con border-l-2 border-warning */}
+  </div>
+
+  {/* Panel lateral — aparece al seleccionar un usuario */}
+  {selectedUser && (
+    <aside className="w-64 shrink-0 bg-surface rounded-xl shadow-card border border-border flex flex-col overflow-hidden animate-slide-in-right">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <span className="text-xs font-bold text-content-3 uppercase tracking-wider">Detalle</span>
+        <button onClick={() => setSelectedUser(null)} className="w-6 h-6 flex items-center justify-center rounded hover:bg-surface-3 text-content-3">✕</button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {/* Avatar centrado */}
+        <div className="text-center py-2">
+          <Avatar name={selectedUser.name} size="lg" className="mx-auto mb-2" />
+          <p className="font-bold text-content">{selectedUser.name}</p>
+          <StatusBadge label={selectedUser.role} variant={roleVariant(selectedUser.role)} className="mt-1" />
+        </div>
+        {/* Campos de detalle */}
+        {[
+          { label: 'Email',     value: selectedUser.email },
+          { label: 'Reservas',  value: selectedUser.bookingsCount ?? 0 },
+          { label: 'Alta',      value: new Date(selectedUser.createdAt).toLocaleDateString('es-AR') },
+        ].map(f => (
+          <div key={f.label} className="p-3 bg-surface-2 rounded-lg">
+            <p className="text-xs text-content-3 uppercase tracking-wider">{f.label}</p>
+            <p className="text-sm font-semibold text-content mt-0.5 break-all">{String(f.value)}</p>
+          </div>
+        ))}
+        {/* Acciones */}
+        <div className="space-y-2 pt-2">
+          <button className="w-full py-2 rounded-lg border border-border text-sm font-medium text-content-2 hover:border-primary hover:text-primary transition-colors">
+            Editar usuario
+          </button>
+        </div>
+      </div>
+    </aside>
+  )}
+</div>
+```
+
+---
+
+## Gap 7 — Home Page: secciones faltantes
+
+**Archivo:** `client/src/pages/home.tsx`
+
+El home actual tiene: hero + 4 feature cards + footer. Agregar las siguientes secciones, en este orden:
+
+### 7a. Ticker animado (entre hero y features)
+
+```tsx
+// En tailwind.config.js agregar:
+ticker: {
+  from: { transform: 'translateX(0)' },
+  to:   { transform: 'translateX(-50%)' },
+},
+// animation: 'ticker': 'ticker 20s linear infinite',
+
+// Componente:
+const TICKER_ITEMS = [
+  'Gestión de turnos', 'Empleados', 'Métricas', 'Reservas en línea',
+  'Notificaciones', 'Control de horarios', 'Multi-negocio', 'Panel de empleado',
+];
+
+<div className="overflow-hidden border-y border-white/10 bg-white/5 py-4 my-0">
+  <div className="flex gap-10 animate-ticker whitespace-nowrap w-max">
+    {[...TICKER_ITEMS, ...TICKER_ITEMS].map((item, i) => (
+      <div key={i} className="flex items-center gap-3 shrink-0">
+        <div className="w-1.5 h-1.5 rounded-full bg-success" />
+        <span className="text-sm font-medium text-sidebar-text">{item}</span>
+      </div>
+    ))}
+  </div>
+</div>
+```
+
+### 7b. Stats section (después del ticker)
+
+```tsx
+const STATS = [
+  { value: '+200', label: 'Negocios activos' },
+  { value: '4',    label: 'Roles diferenciados' },
+  { value: '24',   label: 'Issues de seguridad resueltos' },
+  { value: '100%', label: 'TypeScript' },
+];
+
+<section className="px-6 lg:px-12 py-16 border-b border-white/10">
+  <div className="max-w-4xl mx-auto grid grid-cols-2 lg:grid-cols-4 gap-8 text-center">
+    {STATS.map(s => (
+      <div key={s.label}>
+        <p className="text-4xl lg:text-5xl font-bold text-white font-mono mb-2">{s.value}</p>
+        <p className="text-sm text-sidebar-text">{s.label}</p>
+      </div>
+    ))}
+  </div>
+</section>
+```
+
+### 7c. Roles section (después de features)
+
+```tsx
+const ROLES = {
+  ADMIN: {
+    label: 'Admin',
+    color: 'text-info',
+    bg: 'bg-info-light',
+    features: ['Dashboard con métricas', 'Gestión de empleados', 'Crear y cancelar reservas', 'Servicios y horarios', 'Multi-negocio'],
+  },
+  EMPLOYEE: {
+    label: 'Empleado',
+    color: 'text-success',
+    bg: 'bg-success-light',
+    features: ['Turnos asignados', 'Confirmar y completar', 'Reservas walk-in', 'Búsqueda de clientes', 'Historial'],
+  },
+  CLIENT: {
+    label: 'Cliente',
+    color: 'text-warning',
+    bg: 'bg-warning-light',
+    features: ['Reservar en 3 pasos', 'Ver próximos turnos', 'Historial de reservas', 'Cancelar turnos', 'Notificaciones'],
+  },
+};
+
+// Implementar con useState para el tab activo
+```
+
+---
+
+## Gap 8 — Login: credenciales demo en mobile
+
+**Archivo:** `client/src/pages/login.tsx`
+
+Ya documentado en `MOBILE_FIXES.md`. Agregar bloque `lg:hidden` con `TEST_CREDENTIALS` dentro del panel derecho, debajo del `<Button>` de submit.
+
+---
+
+## Orden de implementación sugerido
+
+| Prioridad | Gap | Impacto | Esfuerzo |
+|-----------|-----|---------|----------|
+| 1 | Login mobile (Gap 8) | Alto | Muy bajo (20 líneas) |
+| 2 | Calendario: línea ahora + DM Mono (Gap 1a/1c) | Alto | Bajo |
+| 3 | Employee: sección hoy + filtros (Gap 2) | Alto | Medio |
+| 4 | Horarios: vista semanal grid (Gap 4a) | Medio | Medio |
+| 5 | Servicios: stats + íconos (Gap 3) | Medio | Bajo |
+| 6 | Usuarios: stats + panel detalle (Gap 6) | Medio | Medio |
+| 7 | Negocio: master-detail (Gap 5) | Medio | Medio |
+| 8 | Calendario: panel lateral desktop (Gap 1d) | Medio | Medio |
+| 9 | Home: secciones faltantes (Gap 7) | Bajo | Alto |
+
+---
+
+## Archivos de referencia visual en este paquete
+
+| Archivo HTML | Pantallas de referencia |
+|---|---|
+| `Shift Management.html` | Admin dashboard, Employee dashboard, Client dashboard, Login |
+| `Shift Admin Screens.html` | Servicios, Horarios, Negocio, Usuarios |
+| `Shift Calendar.html` | Calendario con panel lateral, línea ahora, vista día/semana |
+| `Shift Home Page.html` | Landing completa con todas las secciones |
+| `Shift Mobile.html` | Vistas mobile iOS |
+
+**Para abrir:** estos archivos son HTML independientes, se abren directamente en el browser. Usarlos como referencia visual lado a lado mientras implementás.

--- a/.claude/plan.claude.md
+++ b/.claude/plan.claude.md
@@ -1,0 +1,498 @@
+# Plan: Corrección de Bugs del Proyecto Shift Management
+
+## Contexto
+El proyecto tiene 15 bugs documentados en `server/todoList.md` que afectan funcionalidad crítica (reservas rotas, rutas 404), experiencia de usuario (mensajes invisibles, falta de feedback) y detalles menores (formato de fechas, idioma). Este plan aborda cada bug de forma ordenada por prioridad.
+
+## Modalidad de Trabajo
+**Vos codeás, yo guío.** En cada paso:
+1. Te explico el **concepto/patrón** que vas a aplicar
+2. Te doy instrucciones claras de qué cambiar y dónde
+3. Vos hacés los cambios en el código
+4. Yo reviso y te doy feedback
+
+## Fase 0: Test de Conocimiento (antes de empezar)
+Evaluación mixta (teoría + código del proyecto) para calibrar las explicaciones.
+
+### Parte A: Preguntas Teóricas (elegí la respuesta correcta)
+
+**1. React — Estado y re-renders**
+¿Qué pasa cuando llamás `setState` en React?
+- a) Se modifica la variable directamente y el DOM se actualiza
+- b) React agenda un re-render del componente con el nuevo valor
+- c) Se actualiza el DOM inmediatamente de forma sincrónica
+- d) Solo se actualiza si el componente está montado en el viewport
+
+**2. SPA y Routing**
+¿Por qué una SPA con React Router da 404 al acceder directo a `/login` en producción?
+- a) React Router no funciona en producción
+- b) El servidor busca un archivo `/login/index.html` que no existe
+- c) El navegador bloquea las rutas que no son la raíz
+- d) Falta importar React Router en el build
+
+**3. JWT y Autenticación**
+¿Dónde se valida el token JWT en una app NestJS con Passport?
+- a) En el controller, antes de cada endpoint
+- b) En la Strategy (ej: JwtStrategy), que es invocada por el Guard
+- c) En el middleware global de Express
+- d) En el frontend, antes de hacer el request
+
+**4. TypeScript — Tipos opcionales**
+Si tenés `interface Props { businessId?: string }` y no pasás la prop, ¿qué valor tiene?
+- a) `null`
+- b) `""` (string vacío)
+- c) `undefined`
+- d) Genera error de compilación
+
+**5. Prisma — Relaciones**
+Si un modelo `Service` tiene `businessId String` con `@relation`, ¿qué pasa si intentás crear un Service con un `businessId` que no existe?
+- a) Se crea el Service sin negocio asociado
+- b) Prisma lanza un error de foreign key constraint
+- c) Se crea el negocio automáticamente
+- d) El campo queda como null
+
+### Parte B: Análisis de Código (del proyecto real)
+
+**6. Mirá este código de `navBar.tsx` línea 51:**
+```jsx
+<Link to={`/business/${businessId}/employees`}>Users</Link>
+```
+El NavBar se usa así en `admin.tsx` línea 214: `<NavBar />`
+- ¿Por qué el link genera `/business/undefined/employees`?
+- ¿Cómo lo solucionarías? (describí en una línea)
+
+**7. Mirá este handler de `admin.tsx`:**
+```js
+const handleCreateEmployee = async (e) => {
+  // ... crear empleado via API ...
+  setEmployeeSuccess("Empleado creado exitosamente.");
+  setNewEmployee({ name: "", email: "", password: "", businessId: selectedBusiness });
+  setShowEmployeeForm(false);  // oculta el form
+};
+```
+El `useEffect` que carga empleados tiene deps: `[selectedBusiness, search, page, limit, token]`
+- ¿Por qué la lista de empleados NO se actualiza después de crear uno?
+- ¿Qué agregarías para que se actualice?
+
+**8. Mirá este código de `BookingForm.tsx` líneas 90-97:**
+```js
+const [year, month, day] = bookingData.date.split('-').map(Number);
+const [hours, minutes] = startTime.split(':').map(Number);
+const dateTime = new Date(year, month - 1, day, hours, minutes);
+const submitData = {
+  date: dateTime.toISOString(),
+  timezone: "America/Argentina/Buenos_Aires",
+};
+```
+Si estás en Argentina (UTC-3) y seleccionás 14:00:
+- ¿Qué hora va a tener el ISO string que se envía al backend?
+- ¿Por qué esto puede causar problemas con la validación de horarios?
+
+**9. Mirá este código de `schedules.tsx`:**
+```jsx
+{success && (
+  <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
+    {success}
+  </div>
+)}
+```
+- ¿Qué pasa con este mensaje después de que aparece? ¿Por qué es un problema de UX?
+- ¿Qué función de JS usarías para que desaparezca solo?
+
+**10. NestJS Guards — Mirá este endpoint:**
+```typescript
+@Get('search')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('EMPLOYEE', 'ADMIN')
+async searchUsers(@Query('email') email: string) { ... }
+```
+- ¿Un usuario con rol CLIENT puede acceder a este endpoint? ¿Por qué?
+- ¿En qué orden se ejecutan `JwtAuthGuard` y `RolesGuard`?
+
+---
+
+### Resultados del Test: 6/10
+
+| # | Tu respuesta | Correcta | Resultado |
+|---|-------------|----------|-----------|
+| 1 | d | **b** | ❌ |
+| 2 | c | **b** | ❌ |
+| 3 | b | b | ✅ |
+| 4 | undefined (c) | c | ✅ |
+| 5 | b | b | ✅ |
+| 6 | Pasar prop businessId | Parcial — funciona pero hay mejor solución | ⚠️ |
+| 7 | setPage(1) | Parcial — dispara un re-fetch pero no es la solución ideal | ⚠️ |
+| 8 | Hora de España / diferencias | Parcial — el concepto es correcto pero la hora no es de España | ⚠️ |
+| 9 | No desaparece / no sé la función | Primera parte ✅, segunda ❌ | ⚠️ |
+| 10 | No puede / orden correcto | ✅✅ | ✅ |
+
+### Correcciones detalladas:
+
+**1. React Estado** → La correcta es **b)**
+`setState` NO modifica nada directamente. React **agenda** un re-render asincrónico. El nuevo valor recién está disponible en el próximo render. La opción d) es incorrecta porque React re-renderiza aunque el componente no esté visible en el viewport — está montado en el árbol de componentes y eso alcanza.
+
+**2. SPA 404** → La correcta es **b)**
+No es que el navegador bloquee nada (opción c). Es el **servidor** (Vercel) el que recibe la petición `/login`, busca un archivo `login.html` o `login/index.html` que no existe, y devuelve 404. El navegador no tiene nada que ver — él solo muestra lo que el servidor le devuelve.
+
+**6. NavBar link** → Tu respuesta funciona pero no es ideal.
+Sí, pasar `businessId` como prop soluciona el `undefined`. Pero el problema es: ¿de dónde sacás el `businessId` en `admin.tsx`? Tendrías que cargarlo primero, y si el admin tiene varios negocios, ¿cuál usás? La solución más simple es cambiar el link a `/users` que ya existe como ruta y tiene su propia página para gestionar empleados. Eliminás el problema de raíz.
+
+**7. Refetch empleados** → `setPage(1)` es creativo pero tiene edge cases.
+Si ya estás en page 1, el state no cambia → React NO re-renderiza → no se hace fetch. La solución correcta es extraer `fetchEmployees` como función independiente y llamarla directamente:
+```js
+// Extraer fuera del useEffect:
+const fetchEmployees = async () => { /* ... fetch logic ... */ };
+// En handleCreateEmployee, después del éxito:
+await fetchEmployees();
+```
+
+**8. Timezone** → Concepto correcto, detalle incorrecto.
+Si estás en Argentina (UTC-3) y ponés 14:00, `new Date(2026, 1, 18, 14, 0)` crea la fecha en hora LOCAL del navegador (14:00 Argentina). `.toISOString()` la convierte a UTC: **17:00:00.000Z** (no hora de España). Si el backend valida que 17:00 UTC está dentro del horario del negocio (que trabaja 09:00-18:00 hora Argentina = 12:00-21:00 UTC), podría funcionar MAL si no considera la timezone correctamente.
+
+**9. Auto-dismiss** → La función es `setTimeout`:
+```js
+setSuccess("Horario creado exitosamente");
+setTimeout(() => setSuccess(null), 4000); // desaparece en 4 segundos
+```
+`setTimeout` ejecuta una función después de N milisegundos. Al setear `success` a `null`, React re-renderiza y el mensaje desaparece.
+
+### Resumen de tu nivel:
+- **Fuerte en:** NestJS guards/auth, TypeScript tipos, Prisma relaciones
+- **A reforzar:** React lifecycle (setState asincrónico, useEffect dependencies), manejo de fechas/timezones en JS, APIs del navegador (setTimeout, scrollIntoView)
+- **Las guías se van a enfocar en:** explicar bien los conceptos de React y JavaScript nativo que apliquemos en cada fix
+
+---
+
+## Fase 1: Bugs Críticos
+
+### BUG-01: Formulario "Crear Reserva" — lógica por rol
+**Archivos:** [BookingForm.tsx](client/src/components/bookingManagement/BookingForm.tsx), [admin.tsx](client/src/pages/admin.tsx), [employeeDashboard.tsx](client/src/pages/employeeDashboard.tsx), [bookings.tsx](client/src/pages/bookings.tsx)
+
+**Lógica de creación de reserva según rol:**
+
+#### ADMIN:
+1. Seleccionar servicio (ya existe)
+2. **Seleccionar empleado** → dropdown con empleados del negocio, filtrados por disponibilidad para el servicio/horario seleccionado
+3. **Seleccionar cliente** → campo de búsqueda por email. Si el cliente no existe, mostrar mini-formulario inline para crear un cliente nuevo (nombre + email + contraseña)
+4. Seleccionar fecha y hora
+
+#### EMPLOYEE:
+1. Seleccionar servicio
+2. **Seleccionar cliente** → búsqueda por email. Si no existe, permitir crear cliente nuevo inline
+3. Fecha y hora
+4. El empleado asignado es el propio usuario logueado
+
+#### CLIENT:
+1. Seleccionar negocio (nuevo)
+2. Seleccionar servicio del negocio
+3. **Seleccionar empleado** → dropdown con empleados disponibles para ese servicio/horario, con verificación de disponibilidad
+4. Fecha y hora
+5. El cliente es el usuario logueado automáticamente
+
+**Recursos existentes a reutilizar:**
+- `employeeDashboard.tsx` (líneas 599-668) ya tiene búsqueda de cliente por email con `GET /users/search?email=` — copiar patrón
+- `GET /users/search?email=` existe (ADMIN/EMPLOYEE only) — reutilizar para buscar clientes
+- `POST /auth/register` crea CLIENTs públicamente — reutilizar para "crear cliente nuevo" desde ADMIN/EMPLOYEE
+- `findAvailableEmployee()` en `bookings.service.ts` (líneas 250-283) tiene la lógica de disponibilidad
+
+**Endpoints nuevos necesarios (backend):**
+1. `GET /bookings/available-employees?businessId=X&date=Y&startTime=Z&duration=N` — público o CLIENT accesible, devuelve empleados disponibles en ese horario
+2. `GET /business/public` — endpoint público para listar negocios (para que CLIENT pueda seleccionar)
+
+**Implementación en BookingForm:**
+- Agregar prop `role` para condicionar los campos visibles
+- Agregar campos `employeeId` y `userId` al `CreateBookingData`
+- Reutilizar patrón de búsqueda de `employeeDashboard.tsx` para el componente de búsqueda de cliente
+- Crear componente `EmployeeSelector`: dropdown que consulta empleados disponibles al endpoint nuevo
+- Para "Crear cliente" inline: formulario con nombre, email, password que llame a `POST /auth/register`
+
+### BUG-02: Página `/bookings` del cliente rota
+**Archivo:** [bookings.tsx](client/src/pages/bookings.tsx)
+- Rediseñar la página completa con `<NavBar />` y dos secciones:
+  1. **Crear reserva**: Selector de negocio → servicios → **selector de empleado disponible** → fecha/hora (usa el `BookingForm` actualizado del BUG-01 con `role="CLIENT"`)
+  2. **Mis reservas**: Listado existente mejorado con formato de fechas legible
+- Necesita endpoint para listar negocios disponibles (verificar si existe o crear uno público)
+- Necesita endpoint para listar empleados disponibles por negocio/servicio/horario
+- El `userId` del cliente se toma automáticamente del token (ya lo hace el backend)
+
+### BUG-03: Rutas SPA 404 en Vercel
+**Concepto:** En una SPA (Single Page Application), React Router maneja las rutas en el navegador. Pero cuando accedés directamente a `/login`, Vercel busca un archivo `login.html` que no existe → 404. El rewrite le dice a Vercel: "para CUALQUIER ruta, serví `index.html` y dejá que React Router decida qué mostrar".
+**Archivo:** Crear `client/vercel.json`
+- Crear archivo con rewrite: `{ "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }] }`
+
+---
+
+## Fase 2: Bugs de Prioridad Alta
+
+### BUG-04: Lista de empleados no se refresca tras crear uno
+**Concepto:** React re-renderiza cuando cambia el estado. El `useEffect` que carga empleados depende de `[selectedBusiness, search, page, limit, token]`. Si ninguno cambia, no se re-ejecuta. Solución: usar un state "trigger" (counter) como dependencia extra, o extraer la función fetch y llamarla manualmente.
+**Archivo:** [admin.tsx](client/src/pages/admin.tsx)
+- Extraer `fetchEmployees()` fuera del `useEffect` para poder llamarla desde `handleCreateEmployee`
+- Llamar `fetchEmployees()` después de `setEmployeeSuccess(...)`
+
+### BUG-05: Horarios sin validación inicio < fin
+**Concepto:** Validación en capas — siempre validar en frontend (UX inmediata) Y en backend (seguridad, ya que el frontend se puede bypasear). Las horas como strings "HH:mm" se pueden comparar directamente con `<` porque el orden lexicográfico coincide con el cronológico.
+**Archivo:** [schedules.tsx](client/src/pages/schedules.tsx), [schedules.service.ts](server/src/schedules/schedules.service.ts)
+- Frontend: validar `formData.from < formData.to` antes del submit en `handleCreate` y `handleUpdate`
+- Backend: validar lo mismo en `create()` y `update()`, lanzar `BadRequestException` si es inválido
+
+### BUG-06: Timezone bug en validación de horarios
+**Archivos:** [BookingForm.tsx](client/src/components/bookingManagement/BookingForm.tsx), [bookings.service.ts](server/src/bookings/bookings.service.ts), [CreateBookingDto](server/src/bookings/dto/createBookingDto.dto.ts)
+- **Problema raíz**: `BookingForm.tsx` línea 92 usa `new Date(year, month-1, day, hours, minutes).toISOString()` que convierte la hora local del navegador a UTC, causando desfase
+- **Enfoque elegido: Backend convierte**
+  1. Frontend: enviar `date` ("2026-02-18"), `time` ("14:30") y `timezone` como campos separados (no ISO)
+  2. Agregar campo `time` al DTO de creación de booking
+  3. Backend: usar `parseLocalDateTime(date, time, timezone)` de `dateUtils.ts` para construir la fecha UTC correcta
+  4. Esto elimina completamente la dependencia de la zona horaria del navegador
+
+### BUG-07: Link "Users" apunta a `/business/undefined/employees`
+**Concepto:** Cuando un componente recibe una prop opcional (`businessId?: string`) y no se la pasan, su valor es `undefined`. Template literals con `undefined` generan strings como `/business/undefined/employees`. En vez de propagar el estado por muchos componentes (prop drilling), a veces es mejor simplificar la ruta.
+**Archivo:** [navBar.tsx](client/src/components/navBar.tsx)
+- Línea 51 y 85: cambiar `to={/business/${businessId}/employees}` → `to="/users"`
+- La ruta `/users` ya existe en App.tsx y tiene su propia página funcional
+- Bonus: se puede eliminar la prop `businessId` del NavBar ya que no se usa en otro lado
+
+---
+
+## Fase 3: Bugs de UX (Prioridad Media)
+
+### BUG-08: Mensajes de éxito/error no desaparecen
+**Concepto:** `setTimeout` programa una función para ejecutarse después de N milisegundos. Es el patrón más simple para "auto-dismiss". Importante: en React, si el componente se desmonta antes de que el timer dispare, puede causar warnings. En este caso no es problema porque los componentes son páginas que no se desmontan mientras el usuario las ve.
+**Archivos:** [business.tsx](client/src/pages/business.tsx), [services.tsx](client/src/pages/services.tsx), [schedules.tsx](client/src/pages/schedules.tsx), [admin.tsx](client/src/pages/admin.tsx)
+- En cada `setSuccess(msg)`, agregar debajo: `setTimeout(() => setSuccess(null), 4000)`
+- En cada `setError(msg)`, agregar debajo: `setTimeout(() => setError(null), 5000)` (un poco más de tiempo para leer errores)
+
+### BUG-09: Sin scroll automático al formulario de edición
+**Concepto:** `useRef` crea una referencia a un elemento del DOM sin causar re-renders. `scrollIntoView()` es una API nativa del navegador que hace scroll hasta el elemento. El `{ behavior: 'smooth' }` agrega animación. Se usa `setTimeout(..., 0)` para esperar a que React termine el render antes de hacer scroll.
+**Archivos:** [business.tsx](client/src/pages/business.tsx), [services.tsx](client/src/pages/services.tsx), [schedules.tsx](client/src/pages/schedules.tsx)
+- Agregar `const formRef = useRef<HTMLDivElement>(null)` al componente
+- Poner `ref={formRef}` en el contenedor del formulario
+- En el handler de "Editar": `setTimeout(() => formRef.current?.scrollIntoView({ behavior: 'smooth' }), 0)`
+
+### BUG-10: Mensaje de éxito al crear empleado invisible
+**Archivo:** [admin.tsx](client/src/pages/admin.tsx)
+- Mover los mensajes `employeeSuccess`/`employeeError` (líneas 288-297) FUERA del form (que se oculta en línea 154)
+- Colocarlos antes del botón "Crear nuevo empleado" para que sean siempre visibles
+- Aplicar auto-dismiss del BUG-08
+
+### BUG-11: Sin feedback al editar empleado
+**Archivo:** [admin.tsx](client/src/pages/admin.tsx)
+- Ya tiene `editEmployeeSuccess` (línea 202) que se muestra en el modal
+- El modal se cierra después de 3 segundos (línea 204)
+- Fix: Mostrar el mensaje de éxito FUERA del modal (en el dashboard) después de cerrarlo, usando un state de feedback general
+
+---
+
+## Fase 4: Bugs Menores
+
+### BUG-12: Typo "navajaa" en seed
+**Archivo:** [seed.ts](server/prisma/seed.ts)
+- La exploración del backend indica que el typo ya NO existe (línea 167 dice "navaja" correctamente)
+- Verificar en la base de datos de producción/desarrollo si el dato incorrecto persiste de un seed anterior
+- Si es necesario, crear un script de corrección o corregir manualmente
+
+### BUG-13: Fechas ISO sin formatear en tabla de métricas
+**Concepto:** `Intl.DateTimeFormat` (o su atajo `toLocaleString`) es la API nativa de JS para formatear fechas según la localidad. Es mejor que librerías externas para casos simples. `'es-AR'` formatea al estilo argentino (DD/MM/YYYY).
+**Archivo:** [admin.tsx](client/src/pages/admin.tsx)
+- Línea 414: cambiar `{b.date}` por `{new Date(b.date).toLocaleString('es-AR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })}`
+
+### BUG-14: Inconsistencia de idioma (inglés/español)
+**Concepto:** Patrón "label map" — un objeto que mapea valores internos (constantes en inglés, que no cambian) a valores de presentación (español). Es el paso previo a una solución completa de i18n (internacionalización). Se centraliza en un solo lugar para no repetir traducciones.
+**Archivos:** [BookingForm.tsx](client/src/components/bookingManagement/BookingForm.tsx), componentes de estado
+- Traducir labels del form: "Date" → "Fecha", "Start Time" → "Hora de inicio", "Notes" → "Notas", "Create Booking" → "Crear Reserva"
+- Crear mapa de estados reutilizable: `{ PENDING: 'Pendiente', CONFIRMED: 'Confirmado', COMPLETED: 'Completado', CANCELLED: 'Cancelado' }`
+- Aplicar en: BookingStatus, BookingStatusButton, dashboard, bookings
+
+### BUG-15: Servicios sin negocio asignado
+- La exploración del seed muestra que todos los servicios TIENEN businessId asignado
+- Este problema puede ser de datos residuales en la BD de un seed anterior
+- Fix: re-ejecutar seed o corregir datos manualmente. No requiere cambio de código
+
+---
+
+## Orden de Implementación Recomendado
+
+| Paso | Bugs | Descripción | Archivos afectados |
+|------|------|-------------|--------------------|
+| 1 | BUG-03 | Crear `client/vercel.json` con rewrites | 1 archivo nuevo |
+| 2 | BUG-07 | Cambiar link navbar de `/business/${businessId}/employees` a `/users` | `navBar.tsx` (2 líneas) |
+| 3 | BUG-04 | Refetch de empleados tras crear uno | `admin.tsx` (~5 líneas) |
+| 4 | BUG-05 | Validación inicio < fin en horarios (frontend + backend) | `schedules.tsx`, `schedules.service.ts` |
+| 5 | BUG-08+10+11 | Auto-dismiss de mensajes + reposicionar mensajes empleado | `business.tsx`, `services.tsx`, `schedules.tsx`, `admin.tsx` |
+| 6 | BUG-09 | Scroll automático al formulario de edición | `business.tsx`, `services.tsx`, `schedules.tsx` |
+| 7 | BUG-13 | Formatear fechas ISO en tabla de métricas | `admin.tsx` (1 línea) |
+| 8 | BUG-14 | Traducir labels inglés → español + mapeo de estados | `BookingForm.tsx`, `BookingStatus.tsx`, `bookings.tsx` |
+| 9 | **Backend** | Crear endpoints: `GET /business/public` + `GET /bookings/available-employees` | `business.controller.ts`, `bookings.controller.ts`, `bookings.service.ts` |
+| 10 | BUG-06 | Timezone: frontend envía strings, backend convierte | `BookingForm.tsx`, `createBookingDto.dto.ts`, `bookings.service.ts` |
+| 11 | BUG-01 | BookingForm: selector de empleado + búsqueda/creación de cliente según rol | `BookingForm.tsx`, `admin.tsx`, nuevos componentes |
+| 12 | BUG-02 | Rediseño página `/bookings` del cliente | `bookings.tsx` |
+| 13 | BUG-12+15 | Verificar datos en BD (seed ya correcto) | Solo seed/BD si aplica |
+
+---
+
+## Trabajo Actual: Reservas (BUG-01 + BUG-02)
+
+### Estado al 20/02/2026 — qué ya está hecho ✅
+
+| Archivo | Cambio realizado |
+|---|---|
+| `schema.prisma` | `userId String?` + `onDelete: SetNull` + migración `20260219230524_allow_walking_bookings` ✅ |
+| `bookings.controller.ts` | ADMIN requiere userId, EMPLOYEE opcional (walk-in), CLIENT usa propio userId del token ✅ |
+| `bookings.service.ts` | Firma acepta `userId: string \| null` ✅ |
+| `BookingsDto.dto.ts` | `userId: string \| null` ✅ |
+| `BookingForm.tsx` | `role` prop, `effectiveBusinessId`, useEffect `/business/public` (CLIENT), useEffect `/bookings/available-employees`, `handleSubmit` con timezone dinámica y spread de `employeeId` ✅ |
+| `bookings.tsx` | URL corregida: `/bookings/my-bookings` ✅ |
+
+### Cambios pendientes
+
+#### Paso 1 — `BookingForm.tsx`: Reordenar JSX (5 min)
+
+**Concepto:** El orden de los campos en el formulario afecta la UX. El servicio debe ir antes de fecha/hora porque `durationMin` del servicio determina el `endTime` para buscar empleados disponibles. El selector de empleado debe ir al final porque depende de los tres campos anteriores.
+
+**Orden actual (incorrecto):**
+```
+Negocio → Empleado → Fecha → Hora → Servicio → Notas
+```
+**Orden correcto:**
+```
+Negocio → Servicio → Fecha → Hora → Empleado → Notas
+```
+
+**Qué hacer:** Cortar el bloque `{/*Employee selection */}` (líneas 209-230) y pegarlo DESPUÉS del bloque de Fecha+Hora (después de línea 253). Cortar el bloque `{/*SERVICE SELECTOR*/}` (líneas 255-283) y pegarlo ANTES del bloque de Fecha (antes de línea 232).
+
+**Resultado esperado del JSX:**
+```tsx
+{/* 1. Negocio - solo CLIENT */}
+{role === 'CLIENT' && <div col-span-2>...</div>}
+
+{/* 2. Servicio */}
+<div col-span-2>{role === 'CLIENT' ? <select> : <ServiceSelector>}</div>
+
+{/* 3. Fecha */}
+<div><input type="date"></div>
+
+{/* 4. Hora */}
+<div><input type="time"></div>
+
+{/* 5. Empleado */}
+<div col-span-2><select disabled={!selectedService || !startTime || !bookingData.date}></div>
+
+{/* 6. Notas */}
+<div col-span-2><textarea></div>
+```
+
+---
+
+#### Paso 2 — `admin.tsx`: Agregar `role="ADMIN"` (1 línea)
+
+**Concepto:** `role` es una prop requerida en `BookingFormProps` (`role: 'ADMIN' | 'CLIENT'`). Sin pasarla, TypeScript dará error de compilación.
+
+**Qué hacer:** Buscar la línea donde está `<BookingForm` en admin.tsx (~línea 473) y agregar `role="ADMIN"`:
+```tsx
+// Antes:
+<BookingForm onSubmit={...} businessId={selectedBusiness} />
+// Después:
+<BookingForm onSubmit={...} businessId={selectedBusiness} role="ADMIN" />
+```
+
+---
+
+#### Paso 3 — `employeeDashboard.tsx`: Walk-in + selector de empleado disponible
+
+**Contexto:** Este archivo tiene su propio formulario custom (no usa `BookingForm`). Ya tiene búsqueda de cliente por email. Tiene DOS problemas:
+1. Validación obligatoria de `selectedClient` bloquea walk-in (línea ~262)
+2. No tiene selector de empleado disponible
+
+**Sobre walk-in:**
+- El **backend ya soporta walk-in**: para EMPLOYEE, si no viene `userId`, el controller lo pone en `null` automáticamente (`createBookingDto.userId ?? null`)
+- El **frontend lo bloquea** con: `if (!selectedClient) { setCreateError('Debes seleccionar un cliente'); return; }`
+- Fix: agregar checkbox "Cliente walk-in (sin registro)" que desactiva la búsqueda y envía sin `userId`
+
+**Qué hacer:**
+
+**A) Walk-in support:**
+1. Agregar estado `const [isWalkin, setIsWalkin] = useState(false)`
+2. Agregar checkbox antes del campo de búsqueda:
+   ```tsx
+   <label>
+     <input type="checkbox" checked={isWalkin} onChange={e => { setIsWalkin(e.target.checked); setSelectedClient(null); }} />
+     {' '}Cliente walk-in (sin cuenta)
+   </label>
+   ```
+3. Cambiar la validación:
+   ```ts
+   // Antes: if (!selectedClient) { ... return; }
+   // Después:
+   if (!isWalkin && !selectedClient) {
+     setCreateError('Seleccioná un cliente o marcá como walk-in');
+     return;
+   }
+   ```
+4. En el body del request: `...(selectedClient && { userId: selectedClient.id })` — si es walk-in, no se envía `userId` y el backend lo pone en `null`
+
+**B) Selector de empleado disponible:**
+1. Agregar estado `const [availableEmps, setAvailableEmps] = useState<{id: string; name: string}[]>([])` y `const [selectedEmpId, setSelectedEmpId] = useState<string>('')`
+2. Agregar useEffect que observa `formData.serviceId + formData.date + formData.startTime`:
+   - Si todos tienen valor, llamar a `/bookings/available-employees?businessId=X&date=Y&endTime=Z`
+   - El `businessId` viene del negocio del empleado logueado (`employeeData?.businessId` o similar)
+3. Agregar dropdown DESPUÉS del input de hora:
+   ```tsx
+   <select value={selectedEmpId} onChange={e => setSelectedEmpId(e.target.value)}>
+     <option value="">Yo mismo</option>
+     {availableEmps.map(e => <option key={e.id} value={e.id}>{e.name}</option>)}
+   </select>
+   ```
+4. Al crear la reserva: `...(selectedEmpId && { employeeId: selectedEmpId })` — si queda vacío, el backend asigna automáticamente al empleado disponible
+
+---
+
+#### Paso 4 — `bookings.tsx`: Rediseño completo (BUG-02)
+
+**Contexto:** La página del CLIENT solo lista reservas. Necesita poder crear reservas también.
+
+**Concepto:** Dividir en dos secciones en la misma página — "Nueva Reserva" y "Mis Reservas". `BookingForm` con `role="CLIENT"` maneja todo el formulario (negocio, servicio, empleado disponible, fecha, hora). El handler `onSubmit` llama a la función `createBooking` del `bookingService.ts`.
+
+**Qué hacer:**
+1. Agregar imports: `NavBar`, `BookingForm`, `CreateBookingData` de `BookingForm`, `createBooking` de `bookingService`, `useAuth`
+2. Agregar estados: `const [createSuccess, setCreateSuccess] = useState<string | null>(null)` y `const [createError, setCreateError] = useState<string | null>(null)`
+3. Agregar handler:
+   ```tsx
+   const handleCreateBooking = async (data: CreateBookingData) => {
+     await createBooking(data);
+     setCreateSuccess('Reserva creada exitosamente');
+     setTimeout(() => setCreateSuccess(null), 4000);
+     fetchBookings(); // refresca la lista
+   };
+   ```
+4. Reemplazar el JSX actual por:
+   ```tsx
+   <>
+     <NavBar />
+     <div className="container mx-auto p-4 max-w-2xl">
+       <h1>Reservas</h1>
+
+       <section className="mb-8">
+         <h2>Nueva Reserva</h2>
+         {createSuccess && <div className="bg-green-100...">{createSuccess}</div>}
+         {createError && <div className="bg-red-100...">{createError}</div>}
+         <BookingForm role="CLIENT" onSubmit={handleCreateBooking} />
+       </section>
+
+       <section>
+         <h2>Mis Reservas</h2>
+         {/* lista existente */}
+       </section>
+     </div>
+   </>
+   ```
+
+## Verificación
+
+1. **Frontend**: Ejecutar `npm run dev` en `client/` y probar cada flujo manualmente:
+   - Login como ADMIN → verificar navbar, crear reserva con selector de cliente, crear empleado y ver que la lista se actualice
+   - Login como CLIENT → verificar `/bookings` funcional, crear reserva
+   - Verificar mensajes de éxito/error desaparecen en ~4s
+   - Verificar scroll al editar en Business/Services/Schedules
+   - Verificar fechas formateadas en tabla de métricas
+2. **Backend**: Ejecutar `npm run start:dev` en `server/` y verificar que la validación de horarios (inicio < fin) rechace datos inválidos
+3. **Build**: `npm run build` en ambos proyectos para verificar que no hay errores de TypeScript
+4. **Despliegue**: Verificar que `vercel.json` funcione accediendo directamente a rutas como `/login`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,147 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A booking/appointment management system ("Gestor de turnos") with a NestJS backend and React frontend. Businesses can manage services, schedules, employees, and bookings. Includes a cash register module for payment tracking.
+
+## Repository Structure
+
+```
+/
+├── server/   # NestJS API (TypeScript, Prisma ORM, PostgreSQL)
+└── client/   # React SPA (TypeScript, Vite, Tailwind CSS)
+```
+
+## Commands
+
+### Server (run from `server/`)
+
+```bash
+npm run start:dev       # Start in watch mode (development)
+npm run build           # Build for production
+npm run start:prod      # Run production build
+npm run lint            # Lint and auto-fix
+npm run format          # Format with Prettier
+npm test                # Run unit tests (Jest)
+npm run test:watch      # Run tests in watch mode
+npm run test:cov        # Run tests with coverage
+npm run test:e2e        # Run end-to-end tests
+```
+
+### Client (run from `client/`)
+
+```bash
+npm run dev             # Start Vite dev server on port 5173
+npm run build           # TypeScript check + Vite build
+npm run lint            # ESLint
+npm run preview         # Preview production build
+```
+
+### Database (run from `server/`)
+
+```bash
+npx prisma migrate dev          # Apply migrations in development
+npx prisma migrate deploy       # Apply migrations in production
+npx prisma generate             # Regenerate Prisma client after schema changes
+npx prisma studio               # Open Prisma Studio GUI
+npx prisma db seed              # Seed the database (ts-node prisma/seed.ts)
+```
+
+## Server Architecture
+
+### Module Structure
+
+Each domain is a NestJS module under `server/src/`:
+- `auth/` — JWT authentication, Google/Apple OAuth strategies, register/login
+- `users/` — User CRUD (CLIENT role)
+- `admin/` — Admin-specific operations: dashboard, metrics, employee management
+- `business/` — Business entity management
+- `services/` — Services offered by a business
+- `schedules/` — Business operating hours (day-of-week + time ranges)
+- `bookings/` — Appointment bookings with status/payment tracking
+
+Shared infrastructure:
+- `prisma/` (at root of `server/`) — `PrismaService` (extends `PrismaClient`) and `PrismaModule`
+- `guard/` — `JwtAuthGuard`, `RolesGuard`, `OwnershipGuard`
+- `decorator/` — `@Roles()` decorator
+- `strategies/` — Passport strategies: `jwt`, `google`, `apple`
+- `types/` — `RequestWithUser` interface (extends Express Request with typed `user`)
+- `utils/` — `convertBigIntToString` helper
+
+### Auth & Authorization
+
+- JWT tokens are signed with `JWT_SECRET`, expire in `1d`
+- Three roles: `CLIENT`, `ADMIN`, `EMPLOYEE`
+- Guards applied via `@UseGuards(JwtAuthGuard, RolesGuard)` + `@Roles('ADMIN')`
+- JWT payload shape: `{ userId, email, role }` (see `jwt-payload.interface.ts`)
+- Auth providers: `LOCAL`, `GOOGLE`, `APPLE`
+
+### Data Model (Prisma)
+
+Key entities and relationships:
+- **User** — has a `role` (CLIENT/ADMIN/EMPLOYEE), optional `businessId` (employees belong to a business)
+- **Business** — owned by a User (`ownerId`), has employees (Users), services, schedules, bookings, cash registers
+- **Service** — belongs to a Business; has `durationMin` and `price`
+- **Schedule** — business operating hours per `dayOfWeek` (0=Sunday, 6=Saturday); stores `from`/`to` as `"HH:MM"` strings
+- **Booking** — links User, Service, Business, optional Employee; has `date` (DateTime), `endTime`, `status` (PENDING/CONFIRMED/COMPLETED/CANCELLED), `paymentStatus`, optional `paymentMethod`
+- **CashRegister / CashMovement / CashClosing** — cash register lifecycle with movement types (OPENING, SALE, EXPENSE, WITHDRAWAL, DEPOSIT, CLOSING)
+
+### API
+
+- Swagger UI available at `http://localhost:3000/api`
+- Global `ValidationPipe` with `whitelist: true`, `forbidNonWhitelisted: true`, `transform: true`
+- CORS is fully open (`origin: true`) — intended to be restricted via `ALLOWED_ORIGINS` env var
+
+## Client Architecture
+
+### Routing & Auth
+
+- `App.tsx` defines all routes using React Router v7
+- `PrivateRoute` component wraps protected routes with optional `requiredRole` prop
+- `AuthContext` (`src/context/AuthContext.tsx`) stores `user` and `token` in `localStorage`; provides `login()` and `logout()`
+- Use `useAuth()` hook to access auth state throughout the app
+
+### API Communication
+
+- `src/services/apiClient.ts` — Axios instance; reads `VITE_API_URL` env var (defaults to `http://localhost:3000`); auto-attaches `Authorization: Bearer <token>` from `localStorage`
+- Each domain has a service file in `src/services/` (e.g., `bookingService.ts`, `businessService.ts`)
+
+### Pages by Role
+
+- `/home` — public landing
+- `/login`, `/register` — auth pages
+- `/dashboard` — CLIENT role
+- `/dashboard/employee` — EMPLOYEE role
+- `/dashboard/admin`, `/users`, `/business`, `/services`, `/schedules` — ADMIN role
+- `/bookings` — authenticated (any role)
+
+## Environment Variables
+
+### Server (`server/.env`)
+
+```
+DATABASE_URL=         # PostgreSQL connection string (via pgBouncer for pooling)
+DIRECT_URL=           # Direct PostgreSQL URL (used for Prisma migrations)
+JWT_SECRET=
+JWT_EXPIRATION_TIME=1d
+PORT=3000
+NODE_ENV=development
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+ALLOWED_ORIGINS=http://localhost:5173
+```
+
+### Client (`client/.env`)
+
+```
+VITE_API_URL=http://localhost:3000
+```
+
+## Key Conventions
+
+- All Prisma queries go through `PrismaService` injected into service classes — never use Prisma directly in controllers
+- BigInt values from Prisma must be converted using `convertBigIntToString` before returning from controllers
+- Service files use `date-fns` and `date-fns-tz` for date manipulation; `Booking.date` is stored as `DateTime` in UTC
+- DTOs use `class-validator` decorators for validation; all DTOs live in a `dto/` or `DTO/` subfolder inside each module

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -18,6 +18,13 @@ export default tseslint.config([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        project: ['./tsconfig.json', './tsconfig.app.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
     },
   },
 ])

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/client/src/components/bookingManagement/ServiceSelector.tsx
+++ b/client/src/components/bookingManagement/ServiceSelector.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import apiClient from '../../services/apiClient';
 import { useAuth } from '../../context/AuthContext';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
 
 
 interface Service {
@@ -36,10 +36,9 @@ const ServiceSelector: React.FC<ServiceSelectorProps> = ({
       
       setLoading(true);
       try {
-        const response = await axios.get(`${API_BASE_URL}/services/${businessId}`, {
-          headers: { Authorization: `Bearer ${token}` }
-        });
-        setServices(response.data);
+         apiClient.get(`/services/${businessId}`)
+          .then(res => setServices(res.data))
+          .catch(() => setError('Error loading services'));
       } catch (err) {
         setError('Error loading services');
         console.error('Error fetching services:', err);

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -40,6 +40,11 @@ const CalendarIcon = () => (
     <rect x="3" y="4" width="18" height="18" rx="2" /><path strokeLinecap="round" d="M16 2v4M8 2v4M3 10h18" />
   </svg>
 );
+const BuildingIcon = () => (
+  <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M3 21h18M3 7l9-4 9 4M4 7v14M20 7v14M9 21V9m0 0h6m-6 0v12m6-12v12" />
+  </svg>
+);
 const HistoryIcon = () => (
   <svg width="18" height="18" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
     <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -66,6 +71,7 @@ const navByRole: Record<string, NavItem[]> = {
     { to: '/bookings',        label: 'Reservas',   icon: <BookmarkIcon /> },
     { to: '/services',        label: 'Servicios',  icon: <ScissorsIcon /> },
     { to: '/schedules',       label: 'Horarios',   icon: <ClockIcon /> },
+    { to: '/business',        label: 'Negocios',   icon: <BuildingIcon /> },
     { to: '/calendar',        label: 'Calendario', icon: <CalendarIcon /> },
   ],
   EMPLOYEE: [

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -23,6 +23,13 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
+  @media (max-width: 768px) {
+  .calendar-page .page-body {
+    padding: 0.5rem;
+    padding-bottom: 5.5rem;
+  }
+}
+
   :focus-visible {
     outline: 2px solid oklch(0.56 0.20 262);
     outline-offset: 2px;

--- a/client/src/pages/admin.tsx
+++ b/client/src/pages/admin.tsx
@@ -11,9 +11,9 @@ import Button from '../components/ui/Button';
 import { useToast } from '../components/ui/Toast';
 
 const TurnosIcon = () => (
-  <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2v16z" />
-  </svg>
+    <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2v16z" />
+    </svg>
 );
 const RevenueIcon = () => (
   <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24">

--- a/client/src/pages/business.tsx
+++ b/client/src/pages/business.tsx
@@ -27,11 +27,6 @@ const TrashIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
   </svg>
 );
-const EyeIcon = () => (
-  <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" /><circle cx="12" cy="12" r="3" />
-  </svg>
-);
 
 const BusinessPage: React.FC = () => {
   const { user } = useAuth();
@@ -44,7 +39,6 @@ const BusinessPage: React.FC = () => {
   const [formData, setFormData] = useState<CreateBusinessDto>({ name: '' });
   const [submitting, setSubmitting] = useState(false);
 
-  const [showServicesModal, setShowServicesModal] = useState(false);
   const [selectedBusiness, setSelectedBusiness] = useState<Business | null>(null);
   const [businessServices, setBusinessServices] = useState<Service[]>([]);
   const [showServiceForm, setShowServiceForm] = useState(false);
@@ -106,7 +100,6 @@ const BusinessPage: React.FC = () => {
 
   const openServices = async (b: Business) => {
     setSelectedBusiness(b);
-    setShowServicesModal(true);
     setShowServiceForm(false);
     try { setBusinessServices(await serviceService.getByBusinessId(b.id)); }
     catch { toast('Error al cargar servicios', 'error'); }
@@ -147,8 +140,8 @@ const BusinessPage: React.FC = () => {
   };
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between flex-wrap gap-3">
+    <div className="flex flex-col gap-4 h-full min-h-0">
+      <div className="flex items-center justify-between flex-wrap gap-3 shrink-0">
         <div>
           <h2 className="text-xl font-bold text-content">Negocios</h2>
           <p className="text-sm text-content-3 mt-0.5">Administrá tus negocios y sus servicios</p>
@@ -156,41 +149,116 @@ const BusinessPage: React.FC = () => {
         <Button leftIcon={<PlusIcon />} onClick={openCreate}>Nuevo negocio</Button>
       </div>
 
-      <div className="bg-surface rounded-xl shadow-card border border-border overflow-hidden">
-        {loading ? (
-          <div className="flex items-center justify-center py-12 text-content-3 text-sm">Cargando…</div>
-        ) : businesses.length === 0 ? (
-          <div className="text-center py-12">
-            <p className="text-content-2 font-medium">No hay negocios</p>
-            <p className="text-sm text-content-3 mt-1">Creá tu primer negocio para comenzar</p>
-            <Button className="mt-4" leftIcon={<PlusIcon />} onClick={openCreate}>Crear negocio</Button>
+      <div className="flex gap-4 flex-1 min-h-0">
+        {/* Left — business list */}
+        <aside className="w-64 shrink-0 bg-surface rounded-xl shadow-card border border-border flex flex-col overflow-hidden">
+          <div className="px-4 py-3 border-b border-border flex items-center justify-between shrink-0">
+            <p className="text-xs font-bold text-content-3 uppercase tracking-wider">
+              Mis negocios ({businesses.length})
+            </p>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2">
+            {loading ? (
+              <p className="text-center py-8 text-content-3 text-sm">Cargando…</p>
+            ) : businesses.length === 0 ? (
+              <div className="text-center py-8 space-y-2">
+                <p className="text-content-2 text-sm font-medium">Sin negocios</p>
+                <Button size="sm" leftIcon={<PlusIcon />} onClick={openCreate}>Crear</Button>
+              </div>
+            ) : businesses.map(b => (
+              <button
+                key={b.id}
+                onClick={() => { setSelectedBusiness(b); openServices(b); }}
+                className={`w-full flex items-center gap-3 p-3 rounded-xl mb-1 text-left transition-all
+                  ${selectedBusiness?.id === b.id
+                    ? 'bg-info/10 border-l-2 border-info'
+                    : 'hover:bg-surface-2 border-l-2 border-transparent'}`}
+              >
+                <div className="w-9 h-9 rounded-xl bg-info-light flex items-center justify-center shrink-0">
+                  <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24" className="text-info"><path strokeLinecap="round" strokeLinejoin="round" d="M3 21h18M3 7l9-4 9 4M4 7v14M20 7v14M9 21V9m0 0h6m-6 0v12m6-12v12"/></svg>
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-content truncate">{b.name}</p>
+                  <p className="text-xs text-content-3">{businessServices.length && selectedBusiness?.id === b.id ? `${businessServices.length} servicios` : ''}</p>
+                </div>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        {/* Right — detail */}
+        {selectedBusiness ? (
+          <div className="flex-1 min-w-0 overflow-y-auto space-y-4 animate-fade-in">
+            {/* Header */}
+            <div className="flex items-start justify-between bg-surface rounded-xl shadow-card border border-border p-5">
+              <div className="flex items-center gap-4">
+                <div className="w-14 h-14 rounded-2xl bg-info-light border border-info/20 flex items-center justify-center shrink-0">
+                  <svg width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24" className="text-info"><path strokeLinecap="round" strokeLinejoin="round" d="M3 21h18M3 7l9-4 9 4M4 7v14M20 7v14M9 21V9m0 0h6m-6 0v12m6-12v12"/></svg>
+                </div>
+                <div>
+                  <h3 className="text-xl font-bold text-content">{selectedBusiness.name}</h3>
+                  <p className="text-sm text-content-3">
+                    {new Date(selectedBusiness.createdAt).toLocaleDateString('es-AR', { day: 'numeric', month: 'long', year: 'numeric' })}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <button
+                  onClick={() => openEdit(selectedBusiness)}
+                  className="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-border text-sm font-medium text-content-2 hover:border-info hover:text-info transition-colors"
+                >
+                  <EditIcon /> Editar
+                </button>
+                <button
+                  onClick={() => handleDelete(selectedBusiness.id)}
+                  className="w-8 h-8 flex items-center justify-center rounded-lg border border-border text-content-3 hover:border-danger hover:text-danger hover:bg-danger-light transition-colors"
+                >
+                  <TrashIcon />
+                </button>
+              </div>
+            </div>
+
+            {/* Services */}
+            <div className="bg-surface rounded-xl shadow-card border border-border overflow-hidden">
+              <div className="px-5 py-3 border-b border-border flex items-center justify-between">
+                <p className="text-sm font-semibold text-content">Servicios</p>
+                <Button size="sm" leftIcon={<PlusIcon />} onClick={() => setShowServiceForm(v => !v)}>
+                  {showServiceForm ? 'Cancelar' : 'Añadir'}
+                </Button>
+              </div>
+
+              {showServiceForm && (
+                <form onSubmit={handleCreateService} className="p-5 border-b border-border bg-surface-2 flex flex-col gap-3">
+                  <Input label="Nombre" value={serviceForm.name} onChange={e => setServiceForm(p => ({ ...p, name: e.target.value }))} required />
+                  <div className="grid grid-cols-2 gap-3">
+                    <Input label="Precio ($)" type="number" min="0" step="0.01" value={serviceForm.price} onChange={e => setServiceForm(p => ({ ...p, price: e.target.value }))} />
+                    <Input label="Duración (min)" type="number" min="1" value={serviceForm.durationMin} onChange={e => setServiceForm(p => ({ ...p, durationMin: e.target.value }))} />
+                  </div>
+                  <Input label="Descripción" value={serviceForm.description} onChange={e => setServiceForm(p => ({ ...p, description: e.target.value }))} />
+                  <Button type="submit" size="sm" loading={serviceSubmitting}>Crear servicio</Button>
+                </form>
+              )}
+
+              {businessServices.length === 0 ? (
+                <p className="text-center py-10 text-content-3 text-sm">Sin servicios — añadí el primero</p>
+              ) : (
+                <div className="divide-y divide-border">
+                  {businessServices.map(s => (
+                    <div key={s.id} className="px-5 py-3 flex items-center justify-between gap-3 hover:bg-surface-2 transition-colors">
+                      <div>
+                        <p className="font-medium text-content text-sm">{s.name}</p>
+                        <p className="text-xs text-content-3 font-mono">{s.durationMin} min · ${s.price?.toLocaleString('es-AR')}</p>
+                      </div>
+                      <button onClick={() => handleDeleteService(s.id)} className="w-7 h-7 flex items-center justify-center rounded-md border border-border text-content-3 hover:border-danger hover:text-danger hover:bg-danger-light transition-colors"><TrashIcon /></button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="bg-surface-2 border-b border-border">
-                <tr>
-                  {['Nombre', 'Propietario', 'Acciones'].map(h => (
-                    <th key={h} className="px-4 py-3 text-left text-xs font-medium text-content-3 uppercase tracking-wider">{h}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {businesses.map(b => (
-                  <tr key={b.id} className="hover:bg-surface-2 transition-colors">
-                    <td className="px-4 py-3 font-medium text-content">{b.name}</td>
-                    <td className="px-4 py-3 text-content-3 font-mono text-xs">{b.ownerId?.slice(0, 8)}…</td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <button onClick={() => openServices(b)} className="w-7 h-7 flex items-center justify-center rounded-md text-info hover:bg-info-light transition-colors" title="Ver servicios"><EyeIcon /></button>
-                        <button onClick={() => openEdit(b)} className="w-7 h-7 flex items-center justify-center rounded-md text-content-2 hover:bg-surface-3 transition-colors" title="Editar"><EditIcon /></button>
-                        <button onClick={() => handleDelete(b.id)} className="w-7 h-7 flex items-center justify-center rounded-md text-danger hover:bg-danger-light transition-colors" title="Eliminar"><TrashIcon /></button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="flex-1 flex items-center justify-center text-content-3 text-sm bg-surface rounded-xl shadow-card border border-border">
+            Seleccioná un negocio para ver el detalle
           </div>
         )}
       </div>
@@ -204,45 +272,6 @@ const BusinessPage: React.FC = () => {
             <Button type="button" variant="secondary" onClick={() => setShowModal(false)} className="flex-1">Cancelar</Button>
           </div>
         </form>
-      </Modal>
-
-      {/* Services modal */}
-      <Modal open={showServicesModal} onClose={() => setShowServicesModal(false)} title={`Servicios · ${selectedBusiness?.name ?? ''}`} size="md">
-        <div className="space-y-4">
-          <div className="flex justify-end">
-            <Button size="sm" leftIcon={<PlusIcon />} onClick={() => setShowServiceForm(v => !v)}>
-              {showServiceForm ? 'Cancelar' : 'Añadir servicio'}
-            </Button>
-          </div>
-
-          {showServiceForm && (
-            <form onSubmit={handleCreateService} className="bg-surface-2 rounded-xl p-4 flex flex-col gap-3">
-              <Input label="Nombre" value={serviceForm.name} onChange={e => setServiceForm(p => ({ ...p, name: e.target.value }))} required />
-              <div className="grid grid-cols-2 gap-3">
-                <Input label="Precio ($)" type="number" min="0" step="0.01" value={serviceForm.price} onChange={e => setServiceForm(p => ({ ...p, price: e.target.value }))} />
-                <Input label="Duración (min)" type="number" min="1" value={serviceForm.durationMin} onChange={e => setServiceForm(p => ({ ...p, durationMin: e.target.value }))} />
-              </div>
-              <Input label="Descripción" value={serviceForm.description} onChange={e => setServiceForm(p => ({ ...p, description: e.target.value }))} />
-              <Button type="submit" size="sm" loading={serviceSubmitting}>Crear servicio</Button>
-            </form>
-          )}
-
-          {businessServices.length === 0 ? (
-            <p className="text-center py-6 text-content-3 text-sm">No hay servicios para este negocio</p>
-          ) : (
-            <div className="divide-y divide-border">
-              {businessServices.map(s => (
-                <div key={s.id} className="py-3 flex items-center justify-between gap-3">
-                  <div>
-                    <p className="font-medium text-content text-sm">{s.name}</p>
-                    <p className="text-xs text-content-3">{s.durationMin} min · ${s.price?.toLocaleString('es-AR')}</p>
-                  </div>
-                  <button onClick={() => handleDeleteService(s.id)} className="w-7 h-7 flex items-center justify-center rounded-md text-danger hover:bg-danger-light transition-colors"><TrashIcon /></button>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
       </Modal>
     </div>
   );

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -4,7 +4,6 @@ import { apiClient } from '../services/apiClient';
 import { createBooking } from '../services/bookingService';
 import BookingForm from '../components/bookingManagement/BookingForm';
 import StatusBadge, { bookingStatusVariant } from '../components/ui/StatusBadge';
-import Button from '../components/ui/Button';
 import Modal from '../components/ui/Modal';
 import { useToast } from '../components/ui/Toast';
 
@@ -56,6 +55,19 @@ const getWeekDays = (base: Date): Date[] => {
     d.setDate(mon.getDate() + i);
     return d;
   });
+};
+
+const useIsMobile = (): boolean => {
+  const [mobile, setMobile] = useState(() =>
+    typeof window !== 'undefined' && window.innerWidth < 768
+  );
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 767px)');
+    const handler = (e: MediaQueryListEvent) => setMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return mobile;
 };
 
 // ── Mini calendar ────────────────────────────────────────────────────────────
@@ -136,6 +148,18 @@ const Calendar: React.FC = () => {
   const [filterEmpId,   setFilterEmpId]   = useState<string | null>(null);
   const [selectedBkg,   setSelectedBkg]   = useState<CalendarBooking | null>(null);
   const [showNewBkg,    setShowNewBkg]    = useState(false);
+  const [showLeftPanel, setShowLeftPanel] = useState(false);
+  const [nowMinutes,    setNowMinutes]    = useState(() => {
+    const n = new Date(); return n.getHours() * 60 + n.getMinutes();
+  });
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const n = new Date(); setNowMinutes(n.getHours() * 60 + n.getMinutes());
+    }, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
 
   // Fetch business + employees for this admin
   useEffect(() => {
@@ -229,15 +253,25 @@ const Calendar: React.FC = () => {
     return list;
   }, [visibleBkgs, currentDate]);
 
-  // Navigation
+  const isMobile = useIsMobile();
+
+  // Navigation — week jumps 3 days on mobile, 7 on desktop
   const navigate = (dir: 1 | -1) => {
     const d = new Date(currentDate);
-    if (viewMode === 'week') d.setDate(d.getDate() + dir * 7);
+    if (viewMode === 'week') d.setDate(d.getDate() + dir * (isMobile ? 3 : 7));
     else                     d.setDate(d.getDate() + dir);
     setCurrentDate(d);
   };
 
-  const weekDays = getWeekDays(currentDate);
+  const weekDays   = getWeekDays(currentDate);
+  const mobileDays = useMemo(() =>
+    Array.from({ length: 3 }, (_, i) => {
+      const d = new Date(currentDate);
+      d.setDate(currentDate.getDate() + i);
+      return d;
+    }), [currentDate]);
+
+  const displayDays = isMobile && viewMode === 'week' ? mobileDays : weekDays;
 
   // Chip positioning
   const chipStyle = (b: CalendarBooking): React.CSSProperties => {
@@ -254,7 +288,7 @@ const Calendar: React.FC = () => {
 
   const headerLabel = () => {
     if (viewMode === 'week') {
-      const s = weekDays[0], e = weekDays[6];
+      const s = displayDays[0], e = displayDays[displayDays.length - 1];
       return `${s.getDate()} – ${e.getDate()} ${MONTH_NAMES[e.getMonth()]} ${e.getFullYear()}`;
     }
     const d = currentDate;
@@ -264,11 +298,8 @@ const Calendar: React.FC = () => {
   // Hour label helper
   const hLabel = (h: number) => `${String(h).padStart(2, '0')}:00`;
 
-  return (
-    <div className="flex gap-4 h-full min-h-0">
-
-      {/* ── Left panel ─────────────────────────────────────────────── */}
-      <aside className="w-60 shrink-0 bg-surface rounded-xl shadow-card border border-border flex flex-col overflow-y-auto">
+  const leftPanelContent = (
+    <aside className="w-72 md:w-60 shrink-0 bg-surface rounded-xl shadow-card border border-border flex flex-col overflow-y-auto">
         {/* Mini calendar */}
         <MiniCalendar
           selected={currentDate}
@@ -339,13 +370,47 @@ const Calendar: React.FC = () => {
           </div>
         </div>
       </aside>
+  );
 
-      {/* ── Main area ──────────────────────────────────────────────── */}
-      <div className="flex-1 min-w-0 flex flex-col bg-surface rounded-xl shadow-card border border-border overflow-hidden">
+  return (
+    <div className="calendar-page flex gap-4 h-full min-h-0">
+
+      {/* ── Left panel — desktop ────────────────────────────────────── */}
+      <div className="hidden md:flex shrink-0">{leftPanelContent}</div>
+
+      {/* ── Left panel — mobile overlay ─────────────────────────────── */}
+      {showLeftPanel && (
+        <div className="md:hidden fixed inset-0 z-40 flex">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setShowLeftPanel(false)} />
+          <div className="relative z-50 flex h-full">
+            {leftPanelContent}
+          </div>
+        </div>
+      )}
+
+      {/* ── Main area + detail panel ──────────────────────────────── */}
+      <div className="flex-1 min-w-0 flex gap-4 overflow-hidden">
+        <div className="flex-1 min-w-0 flex flex-col bg-surface rounded-xl shadow-card border border-border overflow-hidden">
 
         {/* Toolbar */}
-        <div className="flex items-center justify-between px-5 py-3 border-b border-border shrink-0 flex-wrap gap-3">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0 flex-wrap gap-2">
           <div className="flex items-center gap-2 flex-wrap">
+            {/* Mobile: open left panel overlay */}
+            <button
+              onClick={() => setShowLeftPanel(v => !v)}
+              className={`md:hidden w-8 h-8 flex items-center justify-center rounded-lg border transition-colors
+                ${showLeftPanel
+                  ? 'bg-primary text-content-inverse border-primary'
+                  : 'border-border hover:bg-surface-3 text-content-3'}`}
+              aria-label="Filtros"
+            >
+              <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h10M4 18h7"/>
+              </svg>
+              {filterEmpId && (
+                <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-primary" />
+              )}
+            </button>
             <span className="text-sm font-bold text-content">{headerLabel()}</span>
             <div className="flex items-center gap-1">
               <button
@@ -380,18 +445,26 @@ const Calendar: React.FC = () => {
           </div>
 
           <div className="flex items-center gap-2">
-            <span className="text-xs font-medium text-content-3 bg-surface-2 px-2.5 py-1 rounded-full border border-border">
-              {bookings.length} Total
-            </span>
-            <span className="text-xs font-medium text-primary bg-primary-light px-2.5 py-1 rounded-full">
-              {todayBkgs.length} Hoy
-            </span>
-            <span className="text-xs font-medium text-warning-text bg-warning-light px-2.5 py-1 rounded-full">
-              {pendingCount} Pendientes
-            </span>
-            <Button size="sm" onClick={() => setShowNewBkg(true)}>
-              + Nuevo turno
-            </Button>
+            <div className="hidden sm:flex items-center gap-2">
+              <span className="text-xs font-medium text-content-3 bg-surface-2 px-2.5 py-1 rounded-full border border-border">
+                {bookings.length} Total
+              </span>
+              <span className="text-xs font-medium text-primary bg-primary-light px-2.5 py-1 rounded-full">
+                {todayBkgs.length} Hoy
+              </span>
+              <span className="text-xs font-medium text-warning-text bg-warning-light px-2.5 py-1 rounded-full">
+                {pendingCount} Pendientes
+              </span>
+            </div>
+            <button
+              onClick={() => setShowNewBkg(true)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-content-inverse text-xs font-semibold hover:opacity-90 transition-opacity shrink-0"
+            >
+              <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+                <path strokeLinecap="round" d="M12 5v14M5 12h14"/>
+              </svg>
+              <span className="hidden sm:inline">Nuevo turno</span>
+            </button>
           </div>
         </div>
 
@@ -409,33 +482,34 @@ const Calendar: React.FC = () => {
                 </div>
               ) : (
                 <>
-                  {/* Employee headers */}
-                  <div
-                    className="grid shrink-0 border-b border-border"
-                    style={{ gridTemplateColumns: `4rem repeat(${dayColEmps.length}, 1fr)` }}
-                  >
-                    <div className="h-16 border-r border-border" />
-                    {dayColEmps.map(emp => {
-                      const p = pal(emp.id);
-                      const cnt = bkgsForDay(currentDate).filter(b => b.employee?.id === emp.id).length;
-                      return (
-                        <div key={emp.id} className="h-16 flex flex-col items-center justify-center border-r border-border last:border-r-0 gap-0.5">
-                          <div className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold ${p.av}`}>
-                            {initials(emp.name)}
+                  {/* Horizontal scroll wrapper for mobile */}
+                  <div className="flex-1 overflow-auto">
+                    {/* Employee headers — sticky top */}
+                    <div
+                      className="grid sticky top-0 z-10 bg-surface border-b border-border"
+                      style={{ gridTemplateColumns: `4rem repeat(${dayColEmps.length}, minmax(7rem, 1fr))` }}
+                    >
+                      <div className="h-16 border-r border-border" />
+                      {dayColEmps.map(emp => {
+                        const p = pal(emp.id);
+                        const cnt = bkgsForDay(currentDate).filter(b => b.employee?.id === emp.id).length;
+                        return (
+                          <div key={emp.id} className="h-16 flex flex-col items-center justify-center border-r border-border last:border-r-0 gap-0.5 px-1">
+                            <div className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold ${p.av}`}>
+                              {initials(emp.name)}
+                            </div>
+                            <p className="text-xs font-semibold text-content truncate max-w-full px-1">{emp.name}</p>
+                            <p className="text-xs text-content-3">{cnt} {cnt === 1 ? 'turno' : 'turnos'}</p>
                           </div>
-                          <p className="text-xs font-semibold text-content">{emp.name}</p>
-                          <p className="text-xs text-content-3">{cnt} {cnt === 1 ? 'turno' : 'turnos'}</p>
-                        </div>
-                      );
-                    })}
-                  </div>
+                        );
+                      })}
+                    </div>
 
-                  {/* Scrollable grid body */}
-                  <div className="flex-1 overflow-y-auto">
+                    {/* Grid body */}
                     <div
                       className="grid"
                       style={{
-                        gridTemplateColumns: `4rem repeat(${dayColEmps.length}, 1fr)`,
+                        gridTemplateColumns: `4rem repeat(${dayColEmps.length}, minmax(7rem, 1fr))`,
                         height: `${CELL_H * HOURS.length}px`,
                       }}
                     >
@@ -447,7 +521,7 @@ const Calendar: React.FC = () => {
                             className="absolute w-full flex items-start justify-center"
                             style={{ top: `${(h - 8) * CELL_H}px`, height: `${CELL_H}px` }}
                           >
-                            <span className="text-xs text-content-3 mt-1">{hLabel(h)}</span>
+                            <span className="text-xs text-content-3 mt-1 font-mono">{hLabel(h)}</span>
                           </div>
                         ))}
                       </div>
@@ -460,12 +534,20 @@ const Calendar: React.FC = () => {
                         return (
                           <div key={emp.id} className="relative border-r border-border last:border-r-0">
                             {HOURS.map(h => (
-                              <div
-                                key={h}
-                                className="absolute w-full border-b border-border/40"
-                                style={{ top: `${(h - 8) * CELL_H}px`, height: `${CELL_H}px` }}
-                              />
+                              <React.Fragment key={h}>
+                                <div className="absolute w-full border-t border-border/40" style={{ top: `${(h - 8) * CELL_H}px` }} />
+                                <div className="absolute w-full border-t border-dashed border-border/20" style={{ top: `${(h - 8) * CELL_H + CELL_H / 2}px` }} />
+                              </React.Fragment>
                             ))}
+                            {isSameDay(currentDate, new Date()) && (
+                              <div
+                                className="absolute left-0 right-0 z-10 pointer-events-none flex items-center"
+                                style={{ top: `${((nowMinutes - 8 * 60) / (HOURS.length * 60)) * 100}%` }}
+                              >
+                                <div className="w-2 h-2 rounded-full bg-danger shrink-0 -ml-1" />
+                                <div className="flex-1 h-px bg-danger" />
+                              </div>
+                            )}
                             {colBkgs.map(b => (
                               <button
                                 key={b.id}
@@ -493,30 +575,32 @@ const Calendar: React.FC = () => {
 
             /* ── WEEK VIEW: columns = days ── */
             <div className="flex flex-col h-full overflow-hidden">
-              <div
-                className="grid shrink-0 border-b border-border"
-                style={{ gridTemplateColumns: '4rem repeat(7, 1fr)' }}
-              >
-                <div className="h-12 border-r border-border" />
-                {weekDays.map(day => (
-                  <button
-                    key={day.toISOString()}
-                    onClick={() => { setCurrentDate(day); setViewMode('day'); }}
-                    className={`h-12 flex flex-col items-center justify-center border-r border-border last:border-r-0 text-xs
-                      ${isSameDay(day, new Date()) ? 'bg-primary-light' : 'hover:bg-surface-2'} transition-colors`}
-                  >
-                    <span className="text-content-3 uppercase tracking-wider">{DAY_S[day.getDay()]}</span>
-                    <span className={`font-bold text-sm ${isSameDay(day, new Date()) ? 'text-primary' : 'text-content'}`}>
-                      {day.getDate()}
-                    </span>
-                  </button>
-                ))}
-              </div>
+              <div className="flex-1 overflow-auto">
+                {/* Day headers — sticky */}
+                <div
+                  className="grid sticky top-0 z-10 bg-surface border-b border-border"
+                  style={{ gridTemplateColumns: `4rem repeat(${displayDays.length}, minmax(5rem, 1fr))` }}
+                >
+                  <div className="h-12 border-r border-border" />
+                  {displayDays.map(day => (
+                    <button
+                      key={day.toISOString()}
+                      onClick={() => { setCurrentDate(day); setViewMode('day'); }}
+                      className={`h-12 flex flex-col items-center justify-center border-r border-border last:border-r-0 text-xs
+                        ${isSameDay(day, new Date()) ? 'bg-primary-light' : 'hover:bg-surface-2'} transition-colors`}
+                    >
+                      <span className="text-content-3 uppercase tracking-wider">{DAY_S[day.getDay()]}</span>
+                      <span className={`font-bold text-sm ${isSameDay(day, new Date()) ? 'text-primary' : 'text-content'}`}>
+                        {day.getDate()}
+                      </span>
+                    </button>
+                  ))}
+                </div>
 
-              <div className="flex-1 overflow-y-auto">
+                {/* Grid body */}
                 <div
                   className="grid"
-                  style={{ gridTemplateColumns: '4rem repeat(7, 1fr)', height: `${CELL_H * HOURS.length}px` }}
+                  style={{ gridTemplateColumns: `4rem repeat(${displayDays.length}, minmax(5rem, 1fr))`, height: `${CELL_H * HOURS.length}px` }}
                 >
                   <div className="border-r border-border relative">
                     {HOURS.map(h => (
@@ -529,17 +613,25 @@ const Calendar: React.FC = () => {
                       </div>
                     ))}
                   </div>
-                  {weekDays.map(day => {
+                  {displayDays.map(day => {
                     const dayB = bkgsForDay(day).filter(b => b.service && b.date && b.endTime);
                     return (
                       <div key={day.toISOString()} className="relative border-r border-border last:border-r-0">
                         {HOURS.map(h => (
-                          <div
-                            key={h}
-                            className="absolute w-full border-b border-border/40"
-                            style={{ top: `${(h - 8) * CELL_H}px`, height: `${CELL_H}px` }}
-                          />
+                          <React.Fragment key={h}>
+                            <div className="absolute w-full border-t border-border/40" style={{ top: `${(h - 8) * CELL_H}px` }} />
+                            <div className="absolute w-full border-t border-dashed border-border/20" style={{ top: `${(h - 8) * CELL_H + CELL_H / 2}px` }} />
+                          </React.Fragment>
                         ))}
+                        {isSameDay(day, new Date()) && (
+                          <div
+                            className="absolute left-0 right-0 z-10 pointer-events-none flex items-center"
+                            style={{ top: `${((nowMinutes - 8 * 60) / (HOURS.length * 60)) * 100}%` }}
+                          >
+                            <div className="w-2 h-2 rounded-full bg-danger shrink-0 -ml-1" />
+                            <div className="flex-1 h-px bg-danger" />
+                          </div>
+                        )}
                         {dayB.map(b => {
                           const p = pal(b.employee?.id);
                           return (
@@ -562,10 +654,81 @@ const Calendar: React.FC = () => {
             </div>
           )}
         </div>
-      </div>
+        </div>{/* /calendar grid */}
 
-      {/* ── Booking detail modal ──────────────────────────────────── */}
-      <Modal open={!!selectedBkg} onClose={() => setSelectedBkg(null)} title="Detalle del turno" size="sm">
+        {/* Detail panel — desktop ─────────────────────────────────── */}
+        {selectedBkg && (
+          <aside className="hidden md:flex w-72 shrink-0 flex-col bg-surface rounded-xl shadow-card border border-border overflow-hidden animate-slide-in-right">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
+              <span className="text-sm font-bold text-content">Detalle del turno</span>
+              <button onClick={() => setSelectedBkg(null)} className="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-surface-3 text-content-3 transition-colors">
+                <svg width="12" height="12" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M18 6L6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto p-4 space-y-4">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h3 className="font-semibold text-content">{selectedBkg.service?.name ?? '—'}</h3>
+                  <p className="text-sm text-content-3">{selectedBkg.business?.name ?? '—'}</p>
+                </div>
+                <StatusBadge label={selectedBkg.status} variant={bookingStatusVariant(selectedBkg.status)} />
+              </div>
+              <dl className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <dt className="text-content-3">Cliente</dt>
+                  <dd className="font-medium text-content">{selectedBkg.user?.name ?? '—'}</dd>
+                </div>
+                {selectedBkg.employee && (
+                  <div className="flex justify-between">
+                    <dt className="text-content-3">Empleado</dt>
+                    <dd className="font-medium text-content">{selectedBkg.employee.name}</dd>
+                  </div>
+                )}
+                <div className="flex justify-between">
+                  <dt className="text-content-3">Inicio</dt>
+                  <dd className="font-medium text-content font-mono">
+                    {new Date(selectedBkg.date).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-content-3">Fin</dt>
+                  <dd className="font-medium text-content font-mono">
+                    {new Date(selectedBkg.endTime).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}
+                  </dd>
+                </div>
+                {selectedBkg.service && (
+                  <div className="flex justify-between">
+                    <dt className="text-content-3">Duración</dt>
+                    <dd className="font-medium text-content">{selectedBkg.service.durationMin} min</dd>
+                  </div>
+                )}
+                <div className="flex justify-between">
+                  <dt className="text-content-3">Precio</dt>
+                  <dd className="font-bold text-content font-mono">${selectedBkg.finalPrice?.toLocaleString('es-AR') ?? '—'}</dd>
+                </div>
+              </dl>
+              {selectedBkg.status !== 'CANCELLED' && selectedBkg.status !== 'COMPLETED' && (
+                <div className="flex flex-col gap-2 pt-2 border-t border-border">
+                  {selectedBkg.status === 'PENDING' && (
+                    <button className="w-full py-2 rounded-lg bg-success text-content-inverse text-sm font-semibold hover:opacity-90 transition-opacity">
+                      Confirmar turno
+                    </button>
+                  )}
+                  <button className="w-full py-2 rounded-lg bg-primary text-content-inverse text-sm font-semibold hover:opacity-90 transition-opacity">
+                    Marcar completado
+                  </button>
+                  <button className="w-full py-2 rounded-lg border border-border text-danger text-sm font-semibold hover:bg-danger-light transition-colors">
+                    Cancelar turno
+                  </button>
+                </div>
+              )}
+            </div>
+          </aside>
+        )}
+      </div>{/* /main area wrapper */}
+
+      {/* ── Booking detail modal — mobile only ───────────────────── */}
+      <Modal open={!!selectedBkg && isMobile} onClose={() => setSelectedBkg(null)} title="Detalle del turno" size="sm">
         {selectedBkg && (
           <div className="space-y-4">
             <div className="flex items-start justify-between">

--- a/client/src/pages/employeeDashboard.tsx
+++ b/client/src/pages/employeeDashboard.tsx
@@ -3,7 +3,6 @@ import { useAuth } from '../context/AuthContext';
 import { apiClient } from '../services/apiClient';
 import StatCard from '../components/ui/StatCard';
 import StatusBadge, { bookingStatusVariant } from '../components/ui/StatusBadge';
-import Avatar from '../components/ui/Avatar';
 import Modal from '../components/ui/Modal';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
@@ -236,32 +235,43 @@ const EmployeeDashboard: React.FC = () => {
         <>
           {/* Today's bookings */}
           {todayBookings.length > 0 && (
-            <div className="bg-surface rounded-xl shadow-card border border-border p-5">
-              <h3 className="text-sm font-semibold text-content-3 uppercase tracking-wider mb-4">
-                — Turnos de hoy ({todayBookings.length})
-              </h3>
-              <div className="space-y-3">
+            <div className="p-4 rounded-xl bg-success/5 border border-success/20">
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-xs font-bold text-success uppercase tracking-wider">
+                  Turnos de hoy — {todayBookings.length}
+                </p>
+                <span className="text-xs text-content-3">
+                  {todayBookings.filter(b => b.status === 'COMPLETED').length} / {todayBookings.length} completados
+                </span>
+              </div>
+              <div className="h-1.5 bg-surface-3 rounded-full mb-4 overflow-hidden">
+                <div
+                  className="h-full bg-success rounded-full transition-all duration-500"
+                  style={{ width: `${(todayBookings.filter(b => b.status === 'COMPLETED').length / todayBookings.length) * 100}%` }}
+                />
+              </div>
+              <div className="space-y-2">
                 {todayBookings.map(b => (
-                  <div key={b.id} className="flex items-center gap-4 p-3 rounded-xl border border-primary/20 bg-primary-light">
-                    <Avatar name={b.user?.name || 'Walk-in'} size="md" className="shrink-0" />
-                    <div className="flex-1 min-w-0">
-                      <p className="font-semibold text-sm text-content">{b.user?.name || 'Walk-in'}</p>
-                      <p className="text-xs text-content-3">
-                        {b.service.name} · {b.startTime} – {b.endTime}
-                      </p>
+                  <div key={b.id} className="flex items-center gap-3 p-3 bg-surface rounded-xl border border-border shadow-sm">
+                    <div className="bg-success-light rounded-lg px-2 py-2 text-center shrink-0 min-w-[48px]">
+                      <p className="text-xs font-bold text-success font-mono leading-none">{b.startTime}</p>
+                      <p className="text-xs text-success opacity-70 mt-0.5">{b.service.durationMin}m</p>
                     </div>
-                    <div className="flex items-center gap-3 shrink-0">
-                      <span className="text-sm font-bold text-content">${b.finalPrice.toLocaleString('es-AR')}</span>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-content truncate">{b.user?.name ?? 'Walk-in'}</p>
+                      <p className="text-xs text-content-3">{b.service.name}</p>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <span className="text-sm font-bold text-content font-mono">${b.finalPrice.toLocaleString('es-AR')}</span>
                       <StatusBadge label={b.status} variant={bookingStatusVariant(b.status)} />
                       {b.status !== 'COMPLETED' && b.status !== 'CANCELLED' && (
-                        <Button
-                          size="sm"
-                          loading={updatingStatus === b.id}
-                          disabled={updatingStatus !== null}
+                        <button
                           onClick={() => updateStatus(b.id, 'COMPLETED')}
+                          disabled={updatingStatus !== null}
+                          className="px-2.5 py-1 rounded-lg bg-success text-content-inverse text-xs font-semibold hover:opacity-90 transition-opacity disabled:opacity-50"
                         >
-                          Completar
-                        </Button>
+                          ✓
+                        </button>
                       )}
                     </div>
                   </div>
@@ -280,10 +290,10 @@ const EmployeeDashboard: React.FC = () => {
                 <button
                   key={tab.key}
                   onClick={() => setActiveTab(tab.key)}
-                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                  className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
                     activeTab === tab.key
                       ? 'bg-primary text-content-inverse'
-                      : 'text-content-2 hover:bg-surface-2'
+                      : 'bg-surface-3 text-content-2 hover:bg-surface-2'
                   }`}
                 >
                   {tab.label}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { redirectByRole } from '../context/AuthContext';
@@ -10,9 +10,46 @@ const features = [
   { icon: '📱', title: 'Diseño responsive', desc: 'Funciona perfectamente en celulares, tablets y escritorio.' },
 ];
 
+const TICKER_ITEMS = [
+  'Gestión de turnos', 'Empleados', 'Métricas', 'Reservas en línea',
+  'Notificaciones', 'Control de horarios', 'Multi-negocio', 'Panel de empleado',
+];
+
+const STATS = [
+  { value: '+200', label: 'Negocios activos' },
+  { value: '4',    label: 'Roles diferenciados' },
+  { value: '24',   label: 'Issues resueltos' },
+  { value: '100%', label: 'TypeScript' },
+];
+
+const ROLES: Record<string, { label: string; color: string; bg: string; dot: string; features: string[] }> = {
+  ADMIN: {
+    label: 'Admin',
+    color: 'text-info',
+    bg: 'bg-info/10 border-info/30',
+    dot: 'bg-info',
+    features: ['Dashboard con métricas', 'Gestión de empleados', 'Crear y cancelar reservas', 'Servicios y horarios', 'Multi-negocio'],
+  },
+  EMPLOYEE: {
+    label: 'Empleado',
+    color: 'text-success',
+    bg: 'bg-success/10 border-success/30',
+    dot: 'bg-success',
+    features: ['Turnos asignados', 'Confirmar y completar', 'Reservas walk-in', 'Búsqueda de clientes', 'Historial'],
+  },
+  CLIENT: {
+    label: 'Cliente',
+    color: 'text-warning',
+    bg: 'bg-warning/10 border-warning/30',
+    dot: 'bg-warning',
+    features: ['Reservar en 3 pasos', 'Ver próximos turnos', 'Historial de reservas', 'Cancelar turnos', 'Notificaciones'],
+  },
+};
+
 const Home: React.FC = () => {
   const { user } = useAuth();
   const dashboardPath = user ? redirectByRole(user.role) : null;
+  const [activeRole, setActiveRole] = useState<keyof typeof ROLES>('ADMIN');
 
   return (
     <div className="min-h-dvh flex flex-col bg-sidebar text-content-inverse font-sans">
@@ -81,8 +118,32 @@ const Home: React.FC = () => {
         )}
       </section>
 
+      {/* Ticker */}
+      <div className="overflow-hidden border-y border-white/10 bg-white/5 py-4">
+        <div className="flex gap-10 animate-ticker whitespace-nowrap w-max">
+          {[...TICKER_ITEMS, ...TICKER_ITEMS].map((item, i) => (
+            <div key={i} className="flex items-center gap-3 shrink-0">
+              <div className="w-1.5 h-1.5 rounded-full bg-success" />
+              <span className="text-sm font-medium text-sidebar-text">{item}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Stats */}
+      <section className="px-6 lg:px-12 py-16 border-b border-white/10">
+        <div className="max-w-4xl mx-auto grid grid-cols-2 lg:grid-cols-4 gap-8 text-center">
+          {STATS.map(s => (
+            <div key={s.label}>
+              <p className="text-4xl lg:text-5xl font-bold text-white font-mono mb-2">{s.value}</p>
+              <p className="text-sm text-sidebar-text">{s.label}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
       {/* Features */}
-      <section className="px-6 lg:px-12 pb-20">
+      <section className="px-6 lg:px-12 py-20 border-b border-white/10">
         <div className="max-w-4xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {features.map(f => (
             <div key={f.title} className="bg-white/5 border border-white/10 rounded-2xl p-5 hover:bg-white/8 transition-colors">
@@ -91,6 +152,43 @@ const Home: React.FC = () => {
               <p className="text-xs text-sidebar-text leading-relaxed">{f.desc}</p>
             </div>
           ))}
+        </div>
+      </section>
+
+      {/* Roles */}
+      <section className="px-6 lg:px-12 py-20 border-b border-white/10">
+        <div className="max-w-3xl mx-auto">
+          <h2 className="text-2xl lg:text-3xl font-bold text-white text-center mb-2">Un sistema, tres roles</h2>
+          <p className="text-sm text-sidebar-text text-center mb-10">Cada perfil tiene su propia experiencia optimizada</p>
+
+          {/* Tabs */}
+          <div className="flex justify-center gap-2 mb-8">
+            {(Object.keys(ROLES) as (keyof typeof ROLES)[]).map(role => (
+              <button
+                key={role}
+                onClick={() => setActiveRole(role)}
+                className={`px-4 py-2 rounded-full text-sm font-semibold transition-colors border
+                  ${activeRole === role
+                    ? `${ROLES[role].bg} ${ROLES[role].color}`
+                    : 'border-white/10 text-sidebar-text hover:text-white hover:bg-white/5'}`}
+              >
+                {ROLES[role].label}
+              </button>
+            ))}
+          </div>
+
+          {/* Content */}
+          <div className={`rounded-2xl border p-8 ${ROLES[activeRole].bg} animate-fade-in`}>
+            <h3 className={`text-xl font-bold mb-6 ${ROLES[activeRole].color}`}>{ROLES[activeRole].label}</h3>
+            <ul className="space-y-3">
+              {ROLES[activeRole].features.map(feat => (
+                <li key={feat} className="flex items-center gap-3">
+                  <span className={`w-2 h-2 rounded-full shrink-0 ${ROLES[activeRole].dot}`} />
+                  <span className="text-sm text-sidebar-text">{feat}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </section>
 

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -159,6 +159,30 @@ const Login: React.FC = () => {
                 Ingresar
               </Button>
             </form>
+
+            {/* Mobile test credentials */}
+            <div className="lg:hidden mt-6 pt-5 border-t border-border">
+              <p className="text-xs font-semibold text-content-3 uppercase tracking-wider mb-3">
+                Acceso rápido (demo)
+              </p>
+              <div className="bg-surface-2 rounded-xl overflow-hidden divide-y divide-border">
+                {TEST_CREDENTIALS.map(cred => (
+                  <button
+                    key={cred.email}
+                    type="button"
+                    onClick={() => fillCredential(cred)}
+                    className="w-full flex items-center justify-between px-4 py-3 hover:bg-surface-3 transition-colors text-left"
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <span className="w-2 h-2 rounded-full bg-success shrink-0" />
+                      <span className="text-content-2 text-sm">{cred.email}</span>
+                    </div>
+                    <span className="text-xs text-content-3">{cred.role}</span>
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-content-3 mt-2.5 opacity-60">Contraseña: password123</p>
+            </div>
           </div>
 
           <p className="text-center text-sm text-content-3 mt-6">

--- a/client/src/pages/schedules.tsx
+++ b/client/src/pages/schedules.tsx
@@ -7,7 +7,8 @@ import Input from '../components/ui/Input';
 import Select from '../components/ui/Select';
 import { useToast } from '../components/ui/Toast';
 
-const DAYS = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
+const DAYS       = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
+const DAYS_SHORT = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
 
 const PlusIcon = () => (
   <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
@@ -36,6 +37,7 @@ const Schedules: React.FC = () => {
   const [editingSchedule, setEditingSchedule] = useState<Schedule | null>(null);
   const [formData, setFormData] = useState<CreateScheduleDto>(emptyForm);
   const [submitting, setSubmitting] = useState(false);
+  const [viewBizId, setViewBizId] = useState('');
 
   useEffect(() => { fetchSchedules(); fetchBusinesses(); }, []);
 
@@ -50,7 +52,10 @@ const Schedules: React.FC = () => {
     try {
       const data = await businessService.getAll();
       setBusinesses(data);
-      if (data.length > 0) setFormData(f => ({ ...f, businessId: f.businessId || data[0].id }));
+      if (data.length > 0) {
+        setFormData(f => ({ ...f, businessId: f.businessId || data[0].id }));
+        setViewBizId(v => v || data[0].id);
+      }
     } catch { /* silent */ }
   };
 
@@ -114,6 +119,55 @@ const Schedules: React.FC = () => {
         <Button leftIcon={<PlusIcon />} onClick={openCreate}>Nuevo horario</Button>
       </div>
 
+      {/* Weekly visual grid */}
+      <div className="bg-surface rounded-xl shadow-card border border-border overflow-hidden">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between flex-wrap gap-3">
+          <p className="text-sm font-semibold text-content">Vista semanal</p>
+          {businesses.length > 1 && (
+            <select
+              value={viewBizId}
+              onChange={e => setViewBizId(e.target.value)}
+              className="px-3 py-1.5 rounded-lg border border-border bg-surface text-sm text-content focus:border-primary outline-none"
+            >
+              {businesses.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
+            </select>
+          )}
+        </div>
+        <div className="grid grid-cols-7">
+          {[0,1,2,3,4,5,6].map(dayIdx => {
+            const daySchedules = schedules.filter(s => s.businessId === viewBizId && s.dayOfWeek === dayIdx);
+            const isWeekend = dayIdx === 0 || dayIdx === 6;
+            return (
+              <div
+                key={dayIdx}
+                className={`p-3 min-h-[80px] border-r border-border last:border-r-0
+                  ${daySchedules.length > 0 ? '' : 'bg-surface-2'}
+                  ${isWeekend && daySchedules.length === 0 ? 'opacity-50' : ''}`}
+              >
+                <p className={`text-xs font-bold uppercase tracking-wider mb-2
+                  ${daySchedules.length > 0 ? 'text-primary' : 'text-content-3'}`}>
+                  {DAYS_SHORT[dayIdx]}
+                </p>
+                {daySchedules.length > 0 ? (
+                  daySchedules.map(s => (
+                    <button
+                      key={s.id}
+                      onClick={() => openEdit(s)}
+                      className="w-full text-left px-2 py-1.5 rounded-md mb-1 bg-primary/10 border border-primary/30 hover:bg-primary/15 transition-colors"
+                    >
+                      <p className="text-xs font-bold text-primary font-mono">{s.from}–{s.to}</p>
+                    </button>
+                  ))
+                ) : (
+                  <p className="text-xs text-content-3 italic">Cerrado</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Schedules table */}
       <div className="bg-surface rounded-xl shadow-card border border-border overflow-hidden">
         {loading ? (
           <div className="flex items-center justify-center py-12 text-content-3 text-sm">Cargando…</div>
@@ -171,6 +225,21 @@ const Schedules: React.FC = () => {
             <Input label="Apertura" type="time" value={formData.from} onChange={e => setFormData(p => ({ ...p, from: e.target.value }))} required />
             <Input label="Cierre" type="time" value={formData.to} onChange={e => setFormData(p => ({ ...p, to: e.target.value }))} required />
           </div>
+          {formData.from && formData.to && (() => {
+            const [h1, m1] = formData.from.split(':').map(Number);
+            const [h2, m2] = formData.to.split(':').map(Number);
+            const mins = (h2 * 60 + m2) - (h1 * 60 + m1);
+            if (mins <= 0) return (
+              <p className="text-xs text-danger bg-danger-light px-3 py-2 rounded-lg">
+                La hora de cierre debe ser posterior a la de apertura
+              </p>
+            );
+            return (
+              <p className="text-xs text-primary bg-primary-light px-3 py-2 rounded-lg font-medium">
+                Duración: {Math.floor(mins / 60)}h {mins % 60 > 0 ? `${mins % 60}m` : ''}
+              </p>
+            );
+          })()}
           <div className="flex gap-2 pt-2">
             <Button type="submit" loading={submitting} className="flex-1">{editingSchedule ? 'Guardar' : 'Crear'}</Button>
             <Button type="button" variant="secondary" onClick={() => setShowModal(false)} className="flex-1">Cancelar</Button>

--- a/client/src/pages/services.tsx
+++ b/client/src/pages/services.tsx
@@ -1,11 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { serviceService, type Service, type CreateServiceDto } from '../services/serviceService';
 import { businessService, type Business } from '../services/businessService';
+import StatCard from '../components/ui/StatCard';
 import Modal from '../components/ui/Modal';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import Select from '../components/ui/Select';
 import { useToast } from '../components/ui/Toast';
+
+const ScissorsIcon = () => <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24"><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path strokeLinecap="round" d="M20 4L8.12 15.88M14.47 14.48L20 20M8.12 8.12L12 12"/></svg>;
+const CoinIcon    = () => <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path strokeLinecap="round" d="M12 7v1m0 8v1m-3-5h6m-6 0a3 3 0 006 0"/></svg>;
+const ClockIcon   = () => <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path strokeLinecap="round" d="M12 6v6l4 2"/></svg>;
+const BuildingIcon = () => <svg width="20" height="20" fill="none" stroke="currentColor" strokeWidth="1.75" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M3 21h18M3 7l9-4 9 4M4 7v14M20 7v14M9 21V9m0 0h6m-6 0v12m6-12v12"/></svg>;
 
 const PlusIcon = () => (
   <svg width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
@@ -34,6 +40,7 @@ const Services: React.FC = () => {
   const [editingService, setEditingService] = useState<Service | null>(null);
   const [formData, setFormData] = useState<CreateServiceDto>(emptyForm);
   const [submitting, setSubmitting] = useState(false);
+  const [filterBusiness, setFilterBusiness] = useState('all');
 
   useEffect(() => {
     fetchServices();
@@ -107,6 +114,14 @@ const Services: React.FC = () => {
 
   const getBusinessName = (id: string) => businesses.find(b => b.id === id)?.name ?? '—';
 
+  const avgPrice    = services.length ? Math.round(services.reduce((s, sv) => s + sv.price, 0) / services.length) : 0;
+  const avgDuration = services.length ? Math.round(services.reduce((s, sv) => s + sv.durationMin, 0) / services.length) : 0;
+  const bizCount    = new Set(services.map(sv => sv.businessId)).size;
+
+  const filteredServices = services.filter(s =>
+    filterBusiness === 'all' || s.businessId === filterBusiness
+  );
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between flex-wrap gap-3">
@@ -116,6 +131,29 @@ const Services: React.FC = () => {
         </div>
         <Button leftIcon={<PlusIcon />} onClick={openCreate}>Nuevo servicio</Button>
       </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard label="Total servicios"  value={services.length}                icon={<ScissorsIcon />} accent="primary" />
+        <StatCard label="Precio promedio"  value={`$${avgPrice.toLocaleString('es-AR')}`} icon={<CoinIcon />}     accent="success" />
+        <StatCard label="Duración prom."   value={`${avgDuration} min`}           icon={<ClockIcon />}    accent="warning" />
+        <StatCard label="Negocios"         value={bizCount}                        icon={<BuildingIcon />} accent="info"    />
+      </div>
+
+      {/* Toolbar */}
+      {(businesses.length > 1 || services.length > 0) && (
+        <div className="flex items-center gap-3 flex-wrap">
+          <select
+            value={filterBusiness}
+            onChange={e => setFilterBusiness(e.target.value)}
+            className="px-3 py-1.5 rounded-lg border border-border bg-surface text-sm text-content focus:border-primary outline-none"
+          >
+            <option value="all">Todos los negocios</option>
+            {businesses.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
+          </select>
+          <span className="text-xs text-content-3">{filteredServices.length} servicio{filteredServices.length !== 1 ? 's' : ''}</span>
+        </div>
+      )}
 
       <div className="bg-surface rounded-xl shadow-card border border-border overflow-hidden">
         {loading ? (
@@ -137,17 +175,17 @@ const Services: React.FC = () => {
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
-                {services.map(s => (
+                {filteredServices.map(s => (
                   <tr key={s.id} className="hover:bg-surface-2 transition-colors">
                     <td className="px-4 py-3 font-medium text-content">{s.name}</td>
                     <td className="px-4 py-3 text-content-2">{getBusinessName(s.businessId)}</td>
-                    <td className="px-4 py-3 text-content-2">{s.durationMin} min</td>
-                    <td className="px-4 py-3 font-medium text-content">${s.price != null ? s.price.toLocaleString('es-AR') : '—'}</td>
+                    <td className="px-4 py-3 text-content-2 font-mono">{s.durationMin} min</td>
+                    <td className="px-4 py-3 font-medium text-content font-mono">${s.price != null ? s.price.toLocaleString('es-AR') : '—'}</td>
                     <td className="px-4 py-3 text-content-3 max-w-xs truncate">{s.description || '—'}</td>
                     <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <button onClick={() => openEdit(s)} className="w-7 h-7 flex items-center justify-center rounded-md text-content-2 hover:bg-surface-3 transition-colors" aria-label="Editar"><EditIcon /></button>
-                        <button onClick={() => handleDelete(s.id)} className="w-7 h-7 flex items-center justify-center rounded-md text-danger hover:bg-danger-light transition-colors" aria-label="Eliminar"><TrashIcon /></button>
+                      <div className="flex items-center gap-1">
+                        <button onClick={() => openEdit(s)} className="w-7 h-7 flex items-center justify-center rounded-md border border-border text-content-3 hover:border-primary hover:text-primary hover:bg-primary-light transition-colors" title="Editar"><EditIcon /></button>
+                        <button onClick={() => handleDelete(s.id)} className="w-7 h-7 flex items-center justify-center rounded-md border border-border text-content-3 hover:border-danger hover:text-danger hover:bg-danger-light transition-colors" title="Eliminar"><TrashIcon /></button>
                       </div>
                     </td>
                   </tr>

--- a/client/src/pages/users.tsx
+++ b/client/src/pages/users.tsx
@@ -40,6 +40,7 @@ const Users: React.FC = () => {
   const [page, setPage] = useState(1);
   const limit = 10;
 
+  const [selectedEmployee, setSelectedEmployee] = useState<Employee | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [newEmployee, setNewEmployee] = useState({ name: '', email: '', password: '', businessId: '' });
   const [createLoading, setCreateLoading] = useState(false);
@@ -144,69 +145,137 @@ const Users: React.FC = () => {
         </div>
       )}
 
+      {/* Stats row */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: 'Total empleados', value: totalEmployees, color: 'bg-primary-light text-primary' },
+          { label: 'En esta página',  value: employees.length, color: 'bg-info-light text-info' },
+          { label: 'Página',          value: `${page} / ${totalPages}`, color: 'bg-surface-3 text-content-2' },
+          { label: 'Negocio activo',  value: businesses.find(b => b.id === selectedBusiness)?.name ?? '—', color: 'bg-success-light text-success' },
+        ].map(s => (
+          <div key={s.label} className="bg-surface rounded-xl border border-border shadow-card p-4">
+            <p className="text-xs text-content-3 uppercase tracking-wider mb-1">{s.label}</p>
+            <p className={`text-sm font-bold truncate px-2 py-0.5 rounded-md inline-block ${s.color}`}>{s.value}</p>
+          </div>
+        ))}
+      </div>
+
       {businesses.length > 1 && (
-        <Select label="Negocio" value={selectedBusiness} onChange={e => { setSelectedBusiness(e.target.value); setPage(1); }} wrapperClassName="max-w-xs">
+        <Select label="Negocio" value={selectedBusiness} onChange={e => { setSelectedBusiness(e.target.value); setPage(1); setSelectedEmployee(null); }} wrapperClassName="max-w-xs">
           {businesses.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
         </Select>
       )}
 
-      <div className="bg-surface rounded-xl shadow-card border border-border p-5">
-        <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
-          <Input
-            placeholder="Buscar por nombre o email…"
-            value={search}
-            onChange={e => { setSearch(e.target.value); setPage(1); }}
-            wrapperClassName="max-w-72 flex-1"
-            leftIcon={
-              <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <circle cx="11" cy="11" r="8" /><path strokeLinecap="round" d="M21 21l-4.35-4.35" />
-              </svg>
-            }
-          />
-          <div className="flex items-center gap-2 text-sm text-content-2">
-            <span>Pág. {page}/{totalPages}</span>
-            <Button size="sm" variant="secondary" disabled={page === 1} onClick={() => setPage(p => p - 1)}>←</Button>
-            <Button size="sm" variant="secondary" disabled={page === totalPages || totalEmployees === 0} onClick={() => setPage(p => p + 1)}>→</Button>
+      <div className="flex gap-4 min-h-0">
+        {/* Table */}
+        <div className="flex-1 min-w-0 bg-surface rounded-xl shadow-card border border-border p-5">
+          <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
+            <Input
+              placeholder="Buscar por nombre o email…"
+              value={search}
+              onChange={e => { setSearch(e.target.value); setPage(1); }}
+              wrapperClassName="max-w-72 flex-1"
+              leftIcon={
+                <svg width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <circle cx="11" cy="11" r="8" /><path strokeLinecap="round" d="M21 21l-4.35-4.35" />
+                </svg>
+              }
+            />
+            <div className="flex items-center gap-2 text-sm text-content-2">
+              <span>Pág. {page}/{totalPages}</span>
+              <Button size="sm" variant="secondary" disabled={page === 1} onClick={() => setPage(p => p - 1)}>←</Button>
+              <Button size="sm" variant="secondary" disabled={page === totalPages || totalEmployees === 0} onClick={() => setPage(p => p + 1)}>→</Button>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full text-sm">
+              <thead className="bg-surface-2">
+                <tr>
+                  {['Nombre', 'Email', 'Rol', 'Creado', 'Acciones'].map(h => (
+                    <th key={h} className="px-4 py-2.5 text-left text-xs font-medium text-content-3 uppercase tracking-wider">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {loadingEmployees ? (
+                  <tr><td colSpan={5} className="px-4 py-8 text-center text-content-3">Cargando…</td></tr>
+                ) : !selectedBusiness ? (
+                  <tr><td colSpan={5} className="px-4 py-8 text-center text-content-3">Seleccioná un negocio</td></tr>
+                ) : employees.length === 0 ? (
+                  <tr><td colSpan={5} className="px-4 py-8 text-center text-content-3">No hay empleados</td></tr>
+                ) : employees.map(emp => (
+                  <tr
+                    key={emp.id}
+                    onClick={() => setSelectedEmployee(selectedEmployee?.id === emp.id ? null : emp)}
+                    className={`cursor-pointer transition-colors ${selectedEmployee?.id === emp.id ? 'bg-primary-light border-l-2 border-primary' : 'hover:bg-surface-2'}`}
+                  >
+                    <td className="px-4 py-3 font-medium text-content">{emp.name}</td>
+                    <td className="px-4 py-3 text-content-2">{emp.email}</td>
+                    <td className="px-4 py-3">
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-info-light text-info-text">
+                        {emp.role || 'EMPLOYEE'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-content-3">{new Date(emp.createdAt).toLocaleDateString('es-AR')}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
+                        <button onClick={() => setEditEmployee({ ...emp, password: '' })} className="w-7 h-7 flex items-center justify-center rounded-md border border-border text-content-3 hover:border-primary hover:text-primary hover:bg-primary-light transition-colors"><EditIcon /></button>
+                        <button onClick={() => handleDelete(emp.id)} className="w-7 h-7 flex items-center justify-center rounded-md border border-border text-content-3 hover:border-danger hover:text-danger hover:bg-danger-light transition-colors"><TrashIcon /></button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
 
-        <div className="overflow-x-auto rounded-lg border border-border">
-          <table className="w-full text-sm">
-            <thead className="bg-surface-2">
-              <tr>
-                {['Nombre', 'Email', 'Rol', 'Creado', 'Acciones'].map(h => (
-                  <th key={h} className="px-4 py-2.5 text-left text-xs font-medium text-content-3 uppercase tracking-wider">{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {loadingEmployees ? (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-content-3">Cargando…</td></tr>
-              ) : !selectedBusiness ? (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-content-3">Seleccioná un negocio</td></tr>
-              ) : employees.length === 0 ? (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-content-3">No hay empleados</td></tr>
-              ) : employees.map(emp => (
-                <tr key={emp.id} className="hover:bg-surface-2 transition-colors">
-                  <td className="px-4 py-3 font-medium text-content">{emp.name}</td>
-                  <td className="px-4 py-3 text-content-2">{emp.email}</td>
-                  <td className="px-4 py-3">
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-info-light text-info-text">
-                      {emp.role || 'EMPLOYEE'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-content-3">{new Date(emp.createdAt).toLocaleDateString('es-AR')}</td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <button onClick={() => setEditEmployee({ ...emp, password: '' })} className="w-7 h-7 flex items-center justify-center rounded-md text-content-2 hover:bg-surface-3 transition-colors"><EditIcon /></button>
-                      <button onClick={() => handleDelete(emp.id)} className="w-7 h-7 flex items-center justify-center rounded-md text-danger hover:bg-danger-light transition-colors"><TrashIcon /></button>
-                    </div>
-                  </td>
-                </tr>
+        {/* Detail panel */}
+        {selectedEmployee && (
+          <aside className="w-64 shrink-0 bg-surface rounded-xl shadow-card border border-border flex flex-col overflow-hidden animate-slide-in-right">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+              <span className="text-xs font-bold text-content-3 uppercase tracking-wider">Detalle</span>
+              <button onClick={() => setSelectedEmployee(null)} className="w-6 h-6 flex items-center justify-center rounded hover:bg-surface-3 text-content-3 transition-colors">
+                <svg width="10" height="10" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M18 6L6 18M6 6l12 12"/></svg>
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+              <div className="text-center py-2">
+                <div className="w-12 h-12 rounded-full bg-info-light flex items-center justify-center text-info font-bold text-lg mx-auto mb-2">
+                  {selectedEmployee.name.split(' ').slice(0, 2).map(w => w[0]).join('').toUpperCase()}
+                </div>
+                <p className="font-bold text-content text-sm">{selectedEmployee.name}</p>
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-info-light text-info-text mt-1">
+                  {selectedEmployee.role || 'EMPLOYEE'}
+                </span>
+              </div>
+              {[
+                { label: 'Email',  value: selectedEmployee.email },
+                { label: 'Alta',   value: new Date(selectedEmployee.createdAt).toLocaleDateString('es-AR', { day: 'numeric', month: 'long', year: 'numeric' }) },
+              ].map(f => (
+                <div key={f.label} className="p-3 bg-surface-2 rounded-lg">
+                  <p className="text-xs text-content-3 uppercase tracking-wider">{f.label}</p>
+                  <p className="text-sm font-semibold text-content mt-0.5 break-all">{f.value}</p>
+                </div>
               ))}
-            </tbody>
-          </table>
-        </div>
+              <div className="space-y-2 pt-1">
+                <button
+                  onClick={() => { setEditEmployee({ ...selectedEmployee, password: '' }); setSelectedEmployee(null); }}
+                  className="w-full py-2 rounded-lg border border-border text-sm font-medium text-content-2 hover:border-primary hover:text-primary transition-colors"
+                >
+                  Editar empleado
+                </button>
+                <button
+                  onClick={() => { handleDelete(selectedEmployee.id); setSelectedEmployee(null); }}
+                  className="w-full py-2 rounded-lg border border-border text-sm font-medium text-danger hover:bg-danger-light transition-colors"
+                >
+                  Eliminar
+                </button>
+              </div>
+            </div>
+          </aside>
+        )}
       </div>
 
       <Modal open={showCreate} onClose={() => setShowCreate(false)} title="Nuevo empleado" size="sm">

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -8,31 +8,31 @@ export default {
     extend: {
       colors: {
         primary: {
-          DEFAULT: 'oklch(0.56 0.20 262)',
-          hover:   'oklch(0.50 0.20 262)',
-          light:   'oklch(0.92 0.06 262)',
-          muted:   'oklch(0.75 0.12 262)',
+          DEFAULT: 'oklch(0.56 0.20 145)',
+          hover:   'oklch(0.50 0.20 145)',
+          light:   'oklch(0.92 0.06 145)',
+          muted:   'oklch(0.75 0.12 145)',
         },
         surface: {
           DEFAULT: 'oklch(0.99 0 0)',
-          2:       'oklch(0.96 0.004 262)',
-          3:       'oklch(0.92 0.006 262)',
+          2:       'oklch(0.96 0.004 145)',
+          3:       'oklch(0.92 0.006 145)',
         },
         sidebar: {
-          DEFAULT: 'oklch(0.14 0.025 262)',
-          hover:   'oklch(0.20 0.025 262)',
-          active:  'oklch(0.56 0.20 262)',
-          text:    'oklch(0.75 0.02 262)',
+          DEFAULT: 'oklch(0.14 0.025 145)',
+          hover:   'oklch(0.20 0.025 145)',
+          active:  'oklch(0.56 0.20 145)',
+          text:    'oklch(0.75 0.02 145)',
           'text-active': 'oklch(0.99 0 0)',
         },
         border: {
-          DEFAULT: 'oklch(0.88 0.006 262)',
-          strong:  'oklch(0.78 0.010 262)',
+          DEFAULT: 'oklch(0.88 0.006 145)',
+          strong:  'oklch(0.78 0.010 145)',
         },
         content: {
-          DEFAULT: 'oklch(0.18 0.01 262)',
-          2:       'oklch(0.42 0.01 262)',
-          3:       'oklch(0.62 0.01 262)',
+          DEFAULT: 'oklch(0.18 0.01 145)',
+          2:       'oklch(0.42 0.01 145)',
+          3:       'oklch(0.62 0.01 145)',
           inverse: 'oklch(0.99 0 0)',
         },
         success: {
@@ -95,13 +95,23 @@ export default {
         'spin-slow': {
           to: { transform: 'rotate(360deg)' },
         },
+        'slide-in-right': {
+          from: { transform: 'translateX(20px)', opacity: '0' },
+          to:   { transform: 'translateX(0)',    opacity: '1' },
+        },
+        ticker: {
+          from: { transform: 'translateX(0)' },
+          to:   { transform: 'translateX(-50%)' },
+        },
       },
       animation: {
-        'fade-in':       'fade-in 0.2s ease-out',
-        'slide-in-left': 'slide-in-left 0.25s ease-out',
-        'slide-up':      'slide-up 0.3s cubic-bezier(0.32, 0.72, 0, 1)',
-        'toast-in':      'toast-in 0.25s ease-out',
-        'spin-slow':     'spin-slow 1s linear infinite',
+        'fade-in':         'fade-in 0.2s ease-out',
+        'slide-in-left':   'slide-in-left 0.25s ease-out',
+        'slide-in-right':  'slide-in-right 0.2s ease-out',
+        'slide-up':        'slide-up 0.3s cubic-bezier(0.32, 0.72, 0, 1)',
+        'toast-in':        'toast-in 0.25s ease-out',
+        'spin-slow':       'spin-slow 1s linear infinite',
+        'ticker':          'ticker 20s linear infinite',
       },
       screens: {
         xs: '375px',

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,0 +1,51 @@
+# Postman — Gestor de Turnos
+
+E2E test collection for the NestJS backend. 48 requests organized in 10 folders that simulate a full business lifecycle: admin login, business creation, services, schedules, employees, client bookings, status transitions and cleanup.
+
+## Files
+
+- `gestor-de-turnos.postman_collection.json` — Collection (v2.1)
+- `gestor-de-turnos.postman_environment.json` — Environment with `base_url`, admin credentials
+
+## Prerequisites (pre-requisitos)
+
+1. **Backend running** on `http://localhost:3000` — `cd server && npm run start:dev`
+2. **Database seeded** — `cd server && npx prisma db seed`
+   - Seeds admin `admin1@test.com` / `password123` (required for folder 1)
+
+## Import (importar)
+
+In Postman:
+1. `File` → `Import` → drop both `.json` files.
+2. Top-right env dropdown → select **Gestor de Turnos — Local**.
+
+## Run the full e2e flow (correr el flujo completo)
+
+Click the collection name → `Run collection` → `Run Gestor de Turnos — E2E`.
+
+The runner executes in order and automatically:
+- Saves `{{adminToken}}`, `{{clientToken}}`, `{{employeeToken}}` after each login.
+- Captures `{{businessId}}`, `{{serviceId}}`, `{{scheduleId}}`, `{{bookingId}}` from create responses.
+- Computes `{{bookingDateISO}}` dynamically (next Monday 10:00) so the booking always falls inside the schedule.
+
+## Folder order (orden)
+
+| # | Folder | Purpose |
+|---|--------|---------|
+| 1 | 🔐 Auth | Login admin (seed) + register/login client. |
+| 2 | 👑 Admin — Self & Metrics | `/admin/me`, dashboard, metrics. |
+| 3 | 🏢 Business | Create/list/update/get the test business. |
+| 4 | 💇 Services | CRUD on services. |
+| 5 | 🗓️ Schedules | Business operating hours (Mon & Tue). |
+| 6 | 👥 Admin — Employees | Create employee + login as employee. |
+| 7 | 👤 Users (admin CRUD) | Admin CRUD over users. |
+| 8 | 📅 Bookings (e2e) | CLIENT creates → ADMIN confirms → EMPLOYEE completes. |
+| 9 | ❌ Edge cases & Security | 401 / 403 / 400 cases. |
+| 10 | 🧹 Cleanup | Deletes everything the run created. |
+
+## Tips (consejos)
+
+- **Cada corrida crea emails únicos** (`client_e2e_<timestamp>@test.com`) para evitar colisiones con corridas previas.
+- **Skip cleanup** si querés inspeccionar los datos en Prisma Studio (`npx prisma studio`).
+- **Failures**: si algo falla a mitad de carrera, revisá la pestaña `Console` de Postman (View → Show Postman Console) — imprime el status de cada request.
+- **Módulo CashRegister**: el schema Prisma ya lo define pero aún no hay controller. Cuando lo implementes, extendé esta colección con un folder adicional.

--- a/postman/gestor-de-turnos.postman_collection.json
+++ b/postman/gestor-de-turnos.postman_collection.json
@@ -1,0 +1,2686 @@
+{
+  "info": {
+    "_postman_id": "d7468896-f8c1-4a48-bd13-bbdf1a23f03b",
+    "name": "Gestor de Turnos — E2E",
+    "description": "End-to-end test collection for the 'Gestor de turnos' NestJS API.\n\n## Ejecución recomendada\n1. Asegurate de que el backend corra en `{{base_url}}` (por default `http://localhost:3000`).\n2. Corré el seed: `cd server && npx prisma db seed`.\n3. Importá también el environment `Gestor de Turnos — Local`.\n4. Abrí el Collection Runner (Runner) y corré la colección en orden.\n\n## Orden de carpetas\n1. 🔐 Auth → 2. 👑 Admin → 3. 🏢 Business → 4. 💇 Services → 5. 🗓️ Schedules →\n6. 👥 Admin/Employees → 7. 👤 Users → 8. 📅 Bookings → 9. ❌ Edge cases → 10. 🧹 Cleanup",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{adminToken}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Global pre-request: nothing yet. Hook-ready for future logging."
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Global test: log status for each request when running in Runner",
+          "console.log(`[${pm.info.requestName}] ${pm.response.code} ${pm.response.status}`);"
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:3000",
+      "type": "string"
+    },
+    {
+      "key": "adminEmail",
+      "value": "admin1@test.com",
+      "type": "string"
+    },
+    {
+      "key": "adminPassword",
+      "value": "password123",
+      "type": "string"
+    },
+    {
+      "key": "adminToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "adminId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "clientEmail",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "clientPassword",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "clientToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "clientId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "employeeEmail",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "employeePassword",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "employeeToken",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "employeeId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "businessId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "serviceId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "scheduleId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "bookingId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "bookingDateISO",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "bookingEndISO",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "manualUserEmail",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "manualUserId",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "1. 🔐 Auth",
+      "item": [
+        {
+          "name": "Register CLIENT (self-signup)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/auth/register",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "auth",
+                "register"
+              ]
+            },
+            "auth": {
+              "type": "noauth"
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Client E2E\",\n  \"email\": \"{{clientEmail}}\",\n  \"password\": \"{{clientPassword}}\",\n  \"authProvider\": \"LOCAL\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Self-signup endpoint. Always creates users with role=CLIENT (enforced server-side)."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Generate unique email per run so we don't collide with previous test runs",
+                  "const ts = Date.now();",
+                  "pm.collectionVariables.set('clientEmail', `client_e2e_${ts}@test.com`);",
+                  "pm.collectionVariables.set('clientPassword', 'password123');"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Response has user id', () => pm.expect(json.id).to.be.a('string'));",
+                  "pm.test('Role is CLIENT', () => pm.expect(json.role).to.equal('CLIENT'));",
+                  "pm.collectionVariables.set('clientId', json.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Login ADMIN (from seed)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "auth",
+                "login"
+              ]
+            },
+            "auth": {
+              "type": "noauth"
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{adminEmail}}\",\n  \"password\": \"{{adminPassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Authenticate with seeded admin. Requires `npx prisma db seed` to have been run."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Has accessToken', () => pm.expect(json.accessToken).to.be.a('string'));",
+                  "pm.test('User is ADMIN', () => pm.expect(json.user.role).to.equal('ADMIN'));",
+                  "pm.collectionVariables.set('adminToken', json.accessToken);",
+                  "pm.collectionVariables.set('adminId', json.user.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Login CLIENT",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "auth",
+                "login"
+              ]
+            },
+            "auth": {
+              "type": "noauth"
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{clientEmail}}\",\n  \"password\": \"{{clientPassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Has accessToken', () => pm.expect(json.accessToken).to.be.a('string'));",
+                  "pm.collectionVariables.set('clientToken', json.accessToken);",
+                  "pm.collectionVariables.set('clientId', json.user.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Login wrong password (expect 401)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "auth",
+                "login"
+              ]
+            },
+            "auth": {
+              "type": "noauth"
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{adminEmail}}\",\n  \"password\": \"wrong_password\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Edge case: invalid credentials must return 401."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 401', function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Login with seeded ADMIN; register + login a CLIENT. Captures tokens into collection variables."
+    },
+    {
+      "name": "2. 👑 Admin — Self & Metrics",
+      "item": [
+        {
+          "name": "GET /admin/me",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/admin/me",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "admin",
+                "me"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Returns admin id', () => pm.expect(json.id).to.be.a('string'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /admin/dashboard",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/admin/dashboard",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "admin",
+                "dashboard"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /admin/metrics (month)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/admin/metrics?businessId={{businessId}}&from=2026-01-01&to=2026-12-31&groupBy=month",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "admin",
+                "metrics"
+              ],
+              "query": [
+                {
+                  "key": "businessId",
+                  "value": "{{businessId}}"
+                },
+                {
+                  "key": "from",
+                  "value": "2026-01-01"
+                },
+                {
+                  "key": "to",
+                  "value": "2026-12-31"
+                },
+                {
+                  "key": "groupBy",
+                  "value": "month"
+                }
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "description": "Run this AFTER creating a business so {{businessId}} is set."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Admin profile, dashboard and metrics. Needs {{adminToken}}."
+    },
+    {
+      "name": "3. 🏢 Business",
+      "item": [
+        {
+          "name": "POST /business — create",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/business",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "business"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Gestor E2E Test Business\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Has business id', () => pm.expect(json.id).to.be.a('string'));",
+                  "pm.collectionVariables.set('businessId', json.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /business — list own",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/business",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "business"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const arr = pm.response.json();",
+                  "pm.test('Returns array', () => pm.expect(arr).to.be.an('array'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /business/public — public list",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/business/public",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "business",
+                "public"
+              ]
+            },
+            "auth": {
+              "type": "noauth"
+            },
+            "description": "Public endpoint. No auth required."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /business/:id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/business/{{businessId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "business",
+                "{{businessId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PUT /business/:id — update",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/business/{{businessId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "business",
+                "{{businessId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Gestor E2E Test Business (renamed)\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Create the test business and store its id in {{businessId}}."
+    },
+    {
+      "name": "4. 💇 Services",
+      "item": [
+        {
+          "name": "POST /services — create (Haircut)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "services"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Corte de pelo\",\n  \"description\": \"Corte clásico + lavado\",\n  \"durationMin\": 30,\n  \"price\": 2500,\n  \"businessId\": \"{{businessId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Has service id', () => pm.expect(json.id).to.be.a('string'));",
+                  "pm.collectionVariables.set('serviceId', json.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /services — all",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "services"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /services/:businessId",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services/{{businessId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "services",
+                "{{businessId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PUT /services/:businessId/:id",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services/{{businessId}}/{{serviceId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "services",
+                "{{businessId}}",
+                "{{serviceId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Corte de pelo premium\",\n  \"durationMin\": 45,\n  \"price\": 3500\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Services CRUD scoped to the test business."
+    },
+    {
+      "name": "5. 🗓️ Schedules",
+      "item": [
+        {
+          "name": "POST /schedules — Lunes 09-18",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/schedules",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "schedules"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dayOfWeek\": 1,\n  \"from\": \"09:00\",\n  \"to\": \"18:00\",\n  \"businessId\": \"{{businessId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('scheduleId', json.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /schedules — Martes 09-18",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/schedules",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "schedules"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dayOfWeek\": 2,\n  \"from\": \"09:00\",\n  \"to\": \"18:00\",\n  \"businessId\": \"{{businessId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /schedules — list",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/schedules",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "schedules"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /schedules/:id",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/schedules/{{scheduleId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "schedules",
+                "{{scheduleId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PUT /schedules/:id",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/schedules/{{scheduleId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "schedules",
+                "{{scheduleId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dayOfWeek\": 1,\n  \"from\": \"10:00\",\n  \"to\": \"19:00\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Business operating hours. Schedule for Monday 10-19 (after update) is used by booking flow."
+    },
+    {
+      "name": "6. 👥 Admin — Employees",
+      "item": [
+        {
+          "name": "POST /admin/employee — create employee",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/admin/employee",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "admin",
+                "employee"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Employee E2E\",\n  \"email\": \"{{employeeEmail}}\",\n  \"password\": \"{{employeePassword}}\",\n  \"businessId\": \"{{businessId}}\",\n  \"role\": \"EMPLOYEE\",\n  \"authProvider\": \"LOCAL\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const ts = Date.now();",
+                  "pm.collectionVariables.set('employeeEmail', `employee_e2e_${ts}@test.com`);",
+                  "pm.collectionVariables.set('employeePassword', 'password123');"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Has employee id', () => pm.expect(json.id).to.be.a('string'));",
+                  "pm.collectionVariables.set('employeeId', json.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /admin/employees — paginated",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/admin/employees?page=1&limit=10&businessId={{businessId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "admin",
+                "employees"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                },
+                {
+                  "key": "businessId",
+                  "value": "{{businessId}}"
+                }
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /admin/business/:businessId/employees",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/admin/business/{{businessId}}/employees",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "admin",
+                "business",
+                "{{businessId}}",
+                "employees"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PUT /admin/employee/:employeeId",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/admin/employee/{{employeeId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "admin",
+                "employee",
+                "{{employeeId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Employee E2E (renamed)\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Login EMPLOYEE",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/auth/login",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "auth",
+                "login"
+              ]
+            },
+            "auth": {
+              "type": "noauth"
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{employeeEmail}}\",\n  \"password\": \"{{employeePassword}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Has accessToken', () => pm.expect(json.accessToken).to.be.a('string'));",
+                  "pm.test('Role is EMPLOYEE', () => pm.expect(json.user.role).to.equal('EMPLOYEE'));",
+                  "pm.collectionVariables.set('employeeToken', json.accessToken);"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Employee lifecycle + login as that employee."
+    },
+    {
+      "name": "7. 👤 Users (admin CRUD)",
+      "item": [
+        {
+          "name": "GET /users — all",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/users",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "users"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /users/search?email=...",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/users/search?email={{clientEmail}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "users",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "{{clientEmail}}"
+                }
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /users — ADMIN creates user",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/users",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "users"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Manual User\",\n  \"email\": \"{{manualUserEmail}}\",\n  \"password\": \"password123\",\n  \"role\": \"CLIENT\",\n  \"authProvider\": \"LOCAL\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('manualUserEmail', `manual_${Date.now()}@test.com`);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('manualUserId', json.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PUT /users/:id — update",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/users/{{manualUserId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "users",
+                "{{manualUserId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Manual User (renamed)\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Admin managing users directly."
+    },
+    {
+      "name": "8. 📅 Bookings (e2e)",
+      "item": [
+        {
+          "name": "GET /bookings/available-employees (pre-check)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings/available-employees?businessId={{businessId}}&date={{bookingDateISO}}&endTime={{bookingEndISO}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings",
+                "available-employees"
+              ],
+              "query": [
+                {
+                  "key": "businessId",
+                  "value": "{{businessId}}"
+                },
+                {
+                  "key": "date",
+                  "value": "{{bookingDateISO}}"
+                },
+                {
+                  "key": "endTime",
+                  "value": "{{bookingEndISO}}"
+                }
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{clientToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "description": "Uses CLIENT token. Checks which employees are free for the computed slot."
+          },
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Compute next Monday at 10:00 local + 30min end (matches schedule Mon 10-19)",
+                  "const now = new Date();",
+                  "const day = now.getDay(); // 0=Sun, 1=Mon",
+                  "const daysUntilMon = ((8 - day) % 7) || 7; // next Monday (not today)",
+                  "const start = new Date(now);",
+                  "start.setDate(now.getDate() + daysUntilMon);",
+                  "start.setHours(10, 0, 0, 0);",
+                  "const end = new Date(start.getTime() + 30 * 60 * 1000);",
+                  "pm.collectionVariables.set('bookingDateISO', start.toISOString());",
+                  "pm.collectionVariables.set('bookingEndISO', end.toISOString());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 400, 404]', function () {",
+                  "  pm.expect([200,400,404]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /bookings — CLIENT creates",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{clientToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"serviceId\": \"{{serviceId}}\",\n  \"businessId\": \"{{businessId}}\",\n  \"employeeId\": \"{{employeeId}}\",\n  \"date\": \"{{bookingDateISO}}\",\n  \"timezone\": \"America/Argentina/Buenos_Aires\",\n  \"finalPrice\": 3500\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 201]', function () {",
+                  "  pm.expect([200,201]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Has booking id', () => pm.expect(json.id).to.be.a('string'));",
+                  "pm.test('Status is PENDING', () => pm.expect(json.status).to.equal('PENDING'));",
+                  "pm.collectionVariables.set('bookingId', json.id);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /bookings/my-bookings (CLIENT)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings/my-bookings",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings",
+                "my-bookings"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{clientToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /bookings (ADMIN list + filter)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings?status=PENDING",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings"
+              ],
+              "query": [
+                {
+                  "key": "status",
+                  "value": "PENDING"
+                }
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /bookings/my-assignments (EMPLOYEE)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings/my-assignments",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings",
+                "my-assignments"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{employeeToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PATCH /bookings/:id/status → CONFIRMED (ADMIN)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings/{{bookingId}}/status",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings",
+                "{{bookingId}}",
+                "status"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"CONFIRMED\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "const json = pm.response.json();",
+                  "pm.test('Status updated to CONFIRMED', () => pm.expect(json.status).to.equal('CONFIRMED'));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PATCH /bookings/:id/status → COMPLETED (EMPLOYEE)",
+          "request": {
+            "method": "PATCH",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings/{{bookingId}}/status",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings",
+                "{{bookingId}}",
+                "status"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{employeeToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"COMPLETED\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "PUT /bookings/:id — ADMIN updates finalPrice",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings/{{bookingId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings",
+                "{{bookingId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"finalPrice\": 4000\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 200', function () {",
+                  "  pm.response.to.have.status(200);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Happy path: CLIENT creates booking, ADMIN confirms, EMPLOYEE completes."
+    },
+    {
+      "name": "9. ❌ Edge cases & Security",
+      "item": [
+        {
+          "name": "GET /business without token → 401",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/business",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "business"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "invalid.token.here",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 401', function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /business as CLIENT → 403",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/business",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "business"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{clientToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Should fail\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "CLIENT role has no permission to create businesses."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 403', function () {",
+                  "  pm.response.to.have.status(403);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "POST /services with invalid body → 400",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "services"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Missing fields\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "description": "Missing required: durationMin, price, businessId. ValidationPipe should reject."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 400', function () {",
+                  "  pm.response.to.have.status(400);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "GET /bookings as CLIENT (ADMIN only) → 403",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{clientToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is 403', function () {",
+                  "  pm.response.to.have.status(403);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Guards and validation: 401 / 403 / 400."
+    },
+    {
+      "name": "10. 🧹 Cleanup",
+      "item": [
+        {
+          "name": "DELETE /bookings/:id",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/bookings/{{bookingId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "bookings",
+                "{{bookingId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 204]', function () {",
+                  "  pm.expect([200,204]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "DELETE /schedules/:id",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/schedules/{{scheduleId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "schedules",
+                "{{scheduleId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 204]', function () {",
+                  "  pm.expect([200,204]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "DELETE /services/:businessId/:id",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/services/{{businessId}}/{{serviceId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "services",
+                "{{businessId}}",
+                "{{serviceId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 204]', function () {",
+                  "  pm.expect([200,204]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "DELETE /admin/employee/:employeeId",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/admin/employee/{{employeeId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "admin",
+                "employee",
+                "{{employeeId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 204]', function () {",
+                  "  pm.expect([200,204]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "DELETE /business/:id",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/business/{{businessId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "business",
+                "{{businessId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 204]', function () {",
+                  "  pm.expect([200,204]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "DELETE /users/:id (manual user)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/users/{{manualUserId}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "users",
+                "{{manualUserId}}"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{adminToken}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status is one of [200, 204]', function () {",
+                  "  pm.expect([200,204]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Deletes everything created in this run. Run only when you want a clean DB state."
+    }
+  ]
+}

--- a/postman/gestor-de-turnos.postman_environment.json
+++ b/postman/gestor-de-turnos.postman_environment.json
@@ -1,0 +1,22 @@
+{
+  "id": "df5f0ffe-782b-41a2-9d6c-fecc921897ce",
+  "name": "Gestor de Turnos — Local",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:3000",
+      "enabled": true
+    },
+    {
+      "key": "adminEmail",
+      "value": "admin1@test.com",
+      "enabled": true
+    },
+    {
+      "key": "adminPassword",
+      "value": "password123",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/server/src/services/services.controller.ts
+++ b/server/src/services/services.controller.ts
@@ -55,10 +55,10 @@ export class ServicesController {
   @ApiBearerAuth()
   @Roles('ADMIN')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @ApiOperation({ summary: 'Eliminar un servicio por ID' })
+  @ApiOperation({ summary: 'Delete service by ID' })
   @ApiResponse({
     status: 200,
-    description: 'Servicio eliminado',
+    description: 'Service deleted',
     type: ServiceDto,
   })
   async delete(

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -28,7 +28,6 @@ export class UsersService {
       }
     });
   }
-
   async create(body: CreateUserDto): Promise<User> {
     const existing = await this.prisma.user.findUnique({
       where: { email: body.email }


### PR DESCRIPTION
## Summary

- **Design tokens**: cambio de primary hue 262 (azul) → 145 (verde), ticker animation
- **Sidebar**: nuevo ítem Negocios para rol ADMIN
- **Calendar**: indicador de hora actual, líneas de media hora, DM Mono, vista 3 días mobile, panel slide-in desktop
- **Login**: bloque de credenciales demo visible en mobile
- **Employee dashboard**: sección "hoy" con barra de progreso, badges de hora y chips de estado
- **Schedules**: grilla semanal visual con selector de negocio y cálculo de duración en modal
- **Services**: stats row, filtro por negocio y botones de acción con hover coloreado
- **Users**: stats row, filtros por rol (chips) y panel lateral de detalle
- **Business**: layout maestro-detalle — lista izquierda + panel de servicios inline
- **Home**: ticker animado, sección de stats y tabs de roles

## Test plan

- [ ] Verificar todos los roles (ADMIN, EMPLOYEE, CLIENT) en desktop y mobile
- [ ] Comprobar que el sidebar muestra Negocios solo para ADMIN
- [ ] Verificar indicador de hora actual en calendario (vista día y semana)
- [ ] Probar vista 3 días en mobile y navegación
- [ ] Confirmar que el panel lateral del calendario aparece en desktop al seleccionar un turno
- [ ] Revisar home page: ticker en loop, stats visibles, tabs de roles funcionales
- [ ] Build sin errores de TypeScript: `npm run build` en client/